### PR TITLE
Move the runtime app depends to a separate bundler group, to reduce

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,6 @@ gem 'faraday', '~> 0.7.5'
 gem 'activesupport', '~> 2.3', :require => 'active_support'
 gem 'yajl-ruby', :require => [ 'yajl', 'yajl/json_gem' ]
 
-gem 'airbrake', '~> 3.0.9'
-
-# New Relic
-gem 'newrelic_rpm', '~> 3.3.0'
-
 # Remote system logging
 gem 'remote_syslog_logger', '~> 1.0.3'
 
@@ -25,9 +20,16 @@ gem 'tinder', '~> 1.7'
 #
 #gem 'always_verify_ssl_certificates', '~> 0.3.0'
 
-gem 'unicorn'
-
 gem 'rake', '~>0.9.2.2'
+
+group :app do
+  gem 'airbrake', '~> 3.0.9'
+
+  # New Relic
+  gem 'newrelic_rpm', '~> 3.3.0'
+
+  gem 'unicorn'
+end
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,7 @@
 require "rubygems"
 require "bundler"
 
-Bundler.require
+Bundler.require :default, :app
 
 if ENV['REMOTE_SYSLOG_URI']
   uri = URI.parse(ENV['REMOTE_SYSLOG_URI'])

--- a/librato-services.gemspec
+++ b/librato-services.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Mike Heffner"]
-  s.date = "2012-03-02"
+  s.date = "2012-03-12"
   s.description = "Provides service notifications for alerts"
   s.email = "mike@librato.com"
   s.extra_rdoc_files = [
@@ -60,12 +60,9 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<faraday>, ["~> 0.7.5"])
       s.add_runtime_dependency(%q<activesupport>, ["~> 2.3"])
       s.add_runtime_dependency(%q<yajl-ruby>, [">= 0"])
-      s.add_runtime_dependency(%q<airbrake>, ["~> 3.0.9"])
-      s.add_runtime_dependency(%q<newrelic_rpm>, ["~> 3.3.0"])
       s.add_runtime_dependency(%q<remote_syslog_logger>, ["~> 1.0.3"])
       s.add_runtime_dependency(%q<mail>, ["~> 2.2"])
       s.add_runtime_dependency(%q<tinder>, ["~> 1.7"])
-      s.add_runtime_dependency(%q<unicorn>, [">= 0"])
       s.add_runtime_dependency(%q<rake>, ["~> 0.9.2.2"])
       s.add_development_dependency(%q<thin>, ["~> 1.2.11"])
       s.add_development_dependency(%q<shotgun>, ["~> 0.8"])
@@ -79,12 +76,9 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<faraday>, ["~> 0.7.5"])
       s.add_dependency(%q<activesupport>, ["~> 2.3"])
       s.add_dependency(%q<yajl-ruby>, [">= 0"])
-      s.add_dependency(%q<airbrake>, ["~> 3.0.9"])
-      s.add_dependency(%q<newrelic_rpm>, ["~> 3.3.0"])
       s.add_dependency(%q<remote_syslog_logger>, ["~> 1.0.3"])
       s.add_dependency(%q<mail>, ["~> 2.2"])
       s.add_dependency(%q<tinder>, ["~> 1.7"])
-      s.add_dependency(%q<unicorn>, [">= 0"])
       s.add_dependency(%q<rake>, ["~> 0.9.2.2"])
       s.add_dependency(%q<thin>, ["~> 1.2.11"])
       s.add_dependency(%q<shotgun>, ["~> 0.8"])
@@ -99,12 +93,9 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<faraday>, ["~> 0.7.5"])
     s.add_dependency(%q<activesupport>, ["~> 2.3"])
     s.add_dependency(%q<yajl-ruby>, [">= 0"])
-    s.add_dependency(%q<airbrake>, ["~> 3.0.9"])
-    s.add_dependency(%q<newrelic_rpm>, ["~> 3.3.0"])
     s.add_dependency(%q<remote_syslog_logger>, ["~> 1.0.3"])
     s.add_dependency(%q<mail>, ["~> 2.2"])
     s.add_dependency(%q<tinder>, ["~> 1.7"])
-    s.add_dependency(%q<unicorn>, [">= 0"])
     s.add_dependency(%q<rake>, ["~> 0.9.2.2"])
     s.add_dependency(%q<thin>, ["~> 1.2.11"])
     s.add_dependency(%q<shotgun>, ["~> 0.8"])


### PR DESCRIPTION
deps when embedding as a gem.
