### PR TITLE
Create annotation on alert notifications

### DIFF
--- a/lib/librato-services/service.rb
+++ b/lib/librato-services/service.rb
@@ -15,7 +15,7 @@ module Librato
         if svc.respond_to?(event_method)
           # XXX: Need a timeout!
           #Timeout.timeout(TIMEOUT, TimeoutError) do
-          svc.send(event_method, *args)
+          svc.send(event_method)
           #end
 
           if event.to_sym == :alert


### PR DESCRIPTION
If the caller supplies an api_client, and the event type is `alert` then it will attempt to send an annotation for the raised alert / notification.
