### PR TITLE
Change PagerDuty alert description to be the name of the alert

### DIFF
--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -22,7 +22,7 @@ class Service::Pagerduty < Service
     body = {
       :service_key => settings[:service_key],
       :event_type => settings[:event_type],
-      :description => settings[:description],
+      :description => payload[:alert][:name],
       :details => pd_payload
     }
 

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -65,6 +65,21 @@ class PagerdutyTest < Librato::Services::TestCase
     svc.receive_alert
   end
 
+  def test_description_is_alert_specific
+    svc = service(:alert, {
+                    :service_key => 'k',
+                    :event_type => 't',
+                    :description => 'd'
+                  }, new_alert_payload)
+
+    @stubs.post '/generic/2010-04-15/create_event.json' do |env|
+      assert_equal "Some alert name", env[:body][:description]
+      [200, {}, '']
+    end
+
+    svc.receive_alert
+  end
+
   def service(*args)
     super Service::Pagerduty, *args
   end


### PR DESCRIPTION
This change makes PagerDuty alerts use the name of the metric that is alerting, instead of the description given in the service integration configuration, which would most likely be something generic like "PagerDuty for Engineering team."

This more accurately reflects how the description is expected by the PagerDuty API documentation at:
http://developer.pagerduty.com/documentation/integration/events/trigger

Once Librato surfaces the "description" field uses for alerts, that should be leveraged here as well.
