### PR TITLE
Slim down the PagerDuty payload

### DIFF
--- a/lib/librato-services/helpers/alert_helpers.rb
+++ b/lib/librato-services/helpers/alert_helpers.rb
@@ -39,6 +39,7 @@ module Librato
         #TODO rename when it's no longer "new"
         def self.sample_new_alert_payload
           ::HashWithIndifferentAccess.new({
+            user_id: 1,
             alert: {id: 123, name: "Some alert name", version: 2},
             auth: {email:"foo@example.com", annotations_token:"lol"},
             settings: {},

--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -17,10 +17,9 @@ class Service::Pagerduty < Service
   def receive_alert
     raise_config_error unless receive_validate({})
 
-    pd_payload = payload.dup
-    # don't send these things in the pagerduty payload
-    ['settings', 'service_type', 'event_type', 'auth'].each do |elided|
-      pd_payload.delete(elided)
+    pd_payload = {}
+    ['user_id', 'alert', 'trigger_time', 'conditions', 'violations'].each do |whitelisted|
+      pd_payload[whitelisted] = payload[whitelisted]
     end
     body = {
       :service_key => settings[:service_key],

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -62,6 +62,11 @@ class PagerdutyTest < Librato::Services::TestCase
       assert_nil env[:body][:details]["settings"]
       assert_nil env[:body][:details]["service_type"]
       assert_nil env[:body][:details]["event_type"]
+      assert_not_nil env[:body][:details]["violations"]
+      assert_not_nil env[:body][:details]["conditions"]
+      assert_not_nil env[:body][:details]["trigger_time"]
+      assert_not_nil env[:body][:details]["alert"]
+      assert_not_nil env[:body][:details]["user_id"]
       [200, {}, '']
     end
 


### PR DESCRIPTION
In addition to the `auth` property of the details section of the pagerduty payload, this also elides `settings`, `service_type`, and `event_type`. Other fields which we may want to trim out later could include `alert_id` and `trigger_time` but my inclination is that those should remain.
