### PR TITLE
Support a 'clear' bool flag in the payload

### DIFF
--- a/lib/librato-services/service.rb
+++ b/lib/librato-services/service.rb
@@ -16,6 +16,15 @@ module Librato
       def self.receive(event, settings, payload, *args)
         svc = new(event, settings, payload)
 
+        if event.to_s == "alert" && payload[:clear]
+          event_method = "receive_alert_clear"
+          if !svc.respond_to?(event_method)
+            return false
+          end
+          svc.send(event_method, *args)
+          return true
+        end
+
         event_method = "receive_#{event}".to_sym
         if svc.respond_to?(event_method)
           # XXX: Need a timeout!

--- a/test/clearing_test.rb
+++ b/test/clearing_test.rb
@@ -1,0 +1,31 @@
+class ClearingTest < Librato::Services::TestCase
+
+  class ClearingService < Service
+    def receive_alert_clear
+    end
+    def sample_payload
+      {}
+    end
+  end
+
+  class NotClearingService < Service
+    def sample_payload
+      {}
+    end
+  end
+
+  def test_sends_clear
+    event = :alert
+    settings = {}
+    payload = { clear: true }
+    assert ClearingService.receive(event, settings, payload)
+  end
+
+  def does_not_send_clear
+    event = :alert
+    settings = {}
+    payload = { clear: true }
+    assert !NotClearingService.receive(event, settings, payload)
+  end
+
+end


### PR DESCRIPTION
- if a service supports clearing then receive_alert_clear will be called
