### PR TITLE
Fix subdomain removal regular expression

### DIFF
--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -96,7 +96,8 @@ class Service::Campfire < Service
   end
 
   def campfire_hostname
-    settings[:subdomain].to_s[/^(.+)(\.campfirenow\.com)?$/, 1]
+    subdomain = settings[:subdomain].to_s
+    subdomain.to_s[/^(.+?)(\.campfirenow\.com)?$/, 1]
   end
 
   def campfire

--- a/test/campfire_test.rb
+++ b/test/campfire_test.rb
@@ -35,6 +35,13 @@ class CampfireTest < Librato::Services::TestCase
     end
   end
 
+  def test_campfire_hostname
+    svc = service(:alert, {"token" => "t", "subdomain" => "s", "room" => "r"}.with_indifferent_access, new_alert_payload)
+    assert_equal "s", svc.campfire_hostname
+    svc = service(:alert, {"token" => "t", "subdomain" => "s.campfirenow.com", "room" => "r"}.with_indifferent_access, new_alert_payload)
+    assert_equal "s", svc.campfire_hostname
+  end
+
   def test_new_alerts_payload
     svc = service(:alert, {"token" => "t", "subdomain" => "s", "room" => "r"}.with_indifferent_access, new_alert_payload)
     svc.campfire = MockCampfire.new


### PR DESCRIPTION
The regular expression was too greedy. By making it non-greedy it now removes `.campfirenow.com` if present from the subdomain.
