### PR TITLE
Clearing for a number of services

### DIFF
--- a/lib/librato-services/helpers/alert_helpers.rb
+++ b/lib/librato-services/helpers/alert_helpers.rb
@@ -41,6 +41,7 @@ module Librato
         def self.sample_new_alert_payload
           ::HashWithIndifferentAccess.new({
             user_id: 1,
+            incident_key: "foo",
             alert: {id: 123, name: "Some alert name", version: 2},
             auth: {email:"foo@example.com", annotations_token:"lol"},
             service_type: "campfire",

--- a/lib/librato-services/service.rb
+++ b/lib/librato-services/service.rb
@@ -19,7 +19,7 @@ module Librato
         if event.to_s == "alert" && payload[:clear]
           event_method = "receive_alert_clear"
           if !svc.respond_to?(event_method)
-            return false
+            return true
           end
           svc.send(event_method, *args)
           return true

--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -34,6 +34,11 @@ class Service::Campfire < Service
                 payload[:snapshot][:image_url]])
   end
 
+  def receive_alert_clear
+    output = Librato::Services::Output.new(payload)
+    paste_message output.markdown
+  end
+
   def receive_alert
     raise_config_error unless receive_validate({})
 

--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -20,6 +20,10 @@ class Service::Hipchat < Service
     errors.empty?
   end
 
+  def receive_alert_clear
+    receive_alert
+  end
+
   def receive_alert
     raise_config_error unless receive_validate({})
     if payload[:alert][:version] == 2

--- a/services/mail.rb
+++ b/services/mail.rb
@@ -23,9 +23,12 @@ class Service::Mail < Service
     true
   end
 
+  def receive_alert_clear
+    receive_alert
+  end
+
   def receive_alert
     raise_config_error unless receive_validate({})
-
     mm = mail_message
     mm.deliver unless mm.to.empty?
   end

--- a/services/opsgenie.rb
+++ b/services/opsgenie.rb
@@ -10,6 +10,16 @@ class Service::OpsGenie < Service
     success
   end
 
+  def receive_alert_clear
+    raise_config_error unless receive_validate({})
+    if settings[:recipients].to_s.empty?
+      settings[:recipients] = "all"
+    end
+    message = "Alert #{payload[:alert][:name]} has cleared"
+    do_post(payload[:alert][:name], message, payload)
+    return
+  end
+
   def receive_alert
     raise_config_error unless receive_validate({})
     if settings[:recipients].to_s.empty?

--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -14,6 +14,10 @@ class Service::Pagerduty < Service
     success
   end
 
+  def receive_alert_clear
+    receive_alert
+  end
+
   def receive_alert
     raise_config_error unless receive_validate({})
 
@@ -30,9 +34,12 @@ class Service::Pagerduty < Service
       :details => pd_payload
     }
 
+    body[:event_type] = payload[:clear] ? "resolve" : "trigger"
     body[:details][:metric_link] = payload_link(payload)
-
-    body[:incident_key] = settings[:incident_key] if settings[:incident_key]
+    keys = [settings[:incident_key], payload[:incident_key]].compact
+    if keys.size > 0
+      body[:incident_key] = keys.join("-")
+    end
 
     url = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
 

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -69,6 +69,36 @@ class PagerdutyTest < Librato::Services::TestCase
       assert_not_nil env[:body][:details]["trigger_time"]
       assert_not_nil env[:body][:details]["alert"]
       assert_not_nil env[:body][:details]["user_id"]
+      assert_equal "trigger", env[:body][:event_type]
+      assert_equal "foo", env[:body][:incident_key]
+      assert_equal 'Some alert name', env[:body][:description]
+      [200, {}, '']
+    end
+
+    svc.receive_alert
+  end
+
+  def test_new_alerts_clearing
+    payload = new_alert_payload.dup
+    payload[:clear] = true
+    svc = service(:alert, {
+                    :service_key => 'k',
+                    :event_type => 't',
+                    :description => 'd'
+                  }, payload)
+
+    @stubs.post '/generic/2010-04-15/create_event.json' do |env|
+      assert_nil env[:body][:details]["auth"]
+      assert_nil env[:body][:details]["settings"]
+      assert_nil env[:body][:details]["service_type"]
+      assert_nil env[:body][:details]["event_type"]
+      assert_not_nil env[:body][:details]["violations"]
+      assert_not_nil env[:body][:details]["conditions"]
+      assert_not_nil env[:body][:details]["trigger_time"]
+      assert_not_nil env[:body][:details]["alert"]
+      assert_not_nil env[:body][:details]["user_id"]
+      assert_equal "resolve", env[:body][:event_type]
+      assert_equal "foo", env[:body][:incident_key]
       assert_equal 'Some alert name', env[:body][:description]
       [200, {}, '']
     end


### PR DESCRIPTION
If a service supports clearing, it should create a `receive_alert_clear` method which will then be called for alert payloads that have `clear:true`.

Unclear at the moment whether or not services like customer-io need the clearing capability --probably not.  The slack integration needs to be done, as well as the impending VictorOps.

The idea here will be to get this into production and testing under a feature-flag and then incrementally support clearing for any services which do not already have it and for which it is applicable.
