### PR TITLE
Ensure that a non-bool type for the clear property still works

### DIFF
--- a/services/webhook.rb
+++ b/services/webhook.rb
@@ -27,7 +27,7 @@ class Service::Webhook < Service
     result = {
       :alert => payload['alert'],
       :trigger_time => payload['trigger_time'],
-      :clear => true
+      :clear => "auto"
     }
     post_it(uri, result)
   end

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -76,7 +76,7 @@ class MailTest < Librato::Services::TestCase
 
   def test_mail_message_new_alert_clear
     payload = new_alert_payload.dup
-    payload[:clear] = true
+    payload[:clear] = "manual"
     svc = service(:alert, { :addresses => 'fred@barn.com' }, payload)
     message = svc.mail_message
     assert_equal "[Librato] Alert Some alert name has cleared.", message.subject

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -80,7 +80,7 @@ class PagerdutyTest < Librato::Services::TestCase
 
   def test_new_alerts_clearing
     payload = new_alert_payload.dup
-    payload[:clear] = true
+    payload[:clear] = "manual"
     svc = service(:alert, {
                     :service_key => 'k',
                     :event_type => 't',


### PR DESCRIPTION
The 'clear' property will become a string that will indicate the clearing reason. These tests ensure that the clearing behavior still works with that field being nil/non-nil and opaque.
