### PR TITLE
Parse the slack url. Reject invalid urls.

### DIFF
--- a/services/slack.rb
+++ b/services/slack.rb
@@ -11,6 +11,12 @@ class Service::Slack < Service
       errors[:url] = "Is required"
       return false
     end
+    begin
+      URI.parse(settings[:url])
+    rescue => e
+      errors[:url] = "Is not valid"
+      return false
+    end
     true
   end
 

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -13,6 +13,12 @@ class SlackTest < Librato::Services::TestCase
     assert(svc.receive_validate(errors))
     assert_equal(0, errors.length)
 
+    # the '/' in the token in this case is invalid
+    svc = service(:alert, @settings.merge(:url => 'https://slack.com/services/hooks/slackbot?token=test_token\&test=true'), new_alert_payload)
+    errors = {}
+    assert(!svc.receive_validate(errors))
+    assert_equal(1, errors.length)
+
     svc = service(:alert, {}, new_alert_payload)
     errors = {}
     assert(!svc.receive_validate(errors))


### PR DESCRIPTION
This will prevent invalid urls from being set.
