### PR TITLE
Ensure that the email subjects stay consistent

### DIFF
--- a/services/mail.rb
+++ b/services/mail.rb
@@ -45,15 +45,10 @@ class Service::Mail < Service
       mail.to      mail_addresses
       mail.header['X-Mailgun-Tag'] = 'alerts'
       trigger_time_utc = Time.at(payload[:trigger_time]).utc
-      case payload[:clear]
-      when nil
-        mail.subject %{[Librato] Alert #{payload[:alert][:name]} has triggered!}
-      when "auto"
-        mail.subject %{[Librato] Alert #{payload[:alert][:name]} was automatically cleared at #{trigger_time_utc}.}
-      when "manual"
-        mail.subject %{[Librato] Alert #{payload[:alert][:name]} was manually cleared at #{trigger_time_utc}.}
+      if payload[:clear]
+        mail.subject %{[Librato] Alert #{payload[:alert][:name]} has cleared.}
       else
-        mail.subject %{[Librato] Alert #{payload[:alert][:name]} has cleared at #{trigger_time_utc}.}
+        mail.subject %{[Librato] Alert #{payload[:alert][:name]} has triggered!}
       end
 
       if payload[:alert][:version] == 2

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -79,7 +79,7 @@ class MailTest < Librato::Services::TestCase
     payload[:clear] = "normal"
     svc = service(:alert, { :addresses => 'fred@barn.com' }, payload)
     message = svc.mail_message
-    assert_equal "[Librato] Alert Some alert name has cleared at 1970-05-23 14:32:03 UTC.", message.subject
+    assert_equal "[Librato] Alert Some alert name has cleared.", message.subject
     assert_not_nil message
     assert(!message.to.empty?)
   end
@@ -89,7 +89,7 @@ class MailTest < Librato::Services::TestCase
     payload[:clear] = "unknown"
     svc = service(:alert, { :addresses => 'fred@barn.com' }, payload)
     message = svc.mail_message
-    assert_equal "[Librato] Alert Some alert name has cleared at 1970-05-23 14:32:03 UTC.", message.subject
+    assert_equal "[Librato] Alert Some alert name has cleared.", message.subject
     assert_not_nil message
     assert(!message.to.empty?)
   end
@@ -99,7 +99,7 @@ class MailTest < Librato::Services::TestCase
     payload[:clear] = "manual"
     svc = service(:alert, { :addresses => 'fred@barn.com' }, payload)
     message = svc.mail_message
-    assert_equal "[Librato] Alert Some alert name was manually cleared at 1970-05-23 14:32:03 UTC.", message.subject
+    assert_equal "[Librato] Alert Some alert name has cleared.", message.subject
     assert_not_nil message
     assert(!message.to.empty?)
   end
@@ -109,7 +109,7 @@ class MailTest < Librato::Services::TestCase
     payload[:clear] = "auto"
     svc = service(:alert, { :addresses => 'fred@barn.com' }, payload)
     message = svc.mail_message
-    assert_equal "[Librato] Alert Some alert name was automatically cleared at 1970-05-23 14:32:03 UTC.", message.subject
+    assert_equal "[Librato] Alert Some alert name has cleared.", message.subject
     assert_not_nil message
     assert(!message.to.empty?)
   end


### PR DESCRIPTION
- will help out with threading for clients that support it

Tests already exist for the message bodies (see the output class) which as used in the email message body payloads -- these differentiate amongst the different types of clearing as well as the timestamps.
