### PR TITLE
Include absent duration in the rendered error message

### DIFF
--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -87,7 +87,7 @@ module Librato
 
       def format_violation_type(condition, measurement)
         if condition[:type] == "absent"
-          "absent"
+          "absent for #{condition[:duration]} seconds"
         else
           "#{condition[:type]} threshold #{threshold(condition, measurement)} with value #{measurement[:value]}"
         end

--- a/test/output_test.rb
+++ b/test/output_test.rb
@@ -112,7 +112,7 @@ EOF
       conditions: [
         {type: "above", threshold: 10, id: 1},
         {type: "below", threshold: 100, id: 2},
-        {type: "absent", threshold: nil, id:3}
+        {type: "absent", threshold: nil, duration:600, id:3}
       ],
       violations: {
         "foo.bar" => [{
@@ -141,7 +141,7 @@ Source `foo.bar`:
 Source `baz.lol`:
 * metric `something.else` was above threshold 10 with value 250 recorded at Fri, Jan 10 2014 at 21:58:03 UTC
 * metric `another.metric` was below threshold 100 with value 10 recorded at Fri, Jan 10 2014 at 21:58:03 UTC
-* metric `i.am.absent` was absent recorded at Fri, Jan 10 2014 at 21:58:03 UTC
+* metric `i.am.absent` was absent for 600 seconds recorded at Fri, Jan 10 2014 at 21:58:03 UTC
 EOF
     assert_equal(expected, output.markdown)
   end


### PR DESCRIPTION
The alert service is already sending the condition duration field in the payload. This update simply includes that value in the rendered alert message for absent measurement conditions
