### PR TITLE
Add alert_link to the payload. Only include metric_link for v1 alerts

### DIFF
--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -35,7 +35,10 @@ class Service::Pagerduty < Service
     }
 
     body[:event_type] = payload[:clear] ? "resolve" : "trigger"
-    body[:details][:metric_link] = payload_link(payload)
+    if payload[:alert][:version] == 1
+      body[:details][:metric_link] = payload_link(payload)
+    end
+    body[:details][:alert_link] = alert_link(payload['alert']['id'])
     keys = [settings[:incident_key], payload[:incident_key]].compact
     if keys.size > 0
       body[:incident_key] = keys.join("-")

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -69,6 +69,8 @@ class PagerdutyTest < Librato::Services::TestCase
       assert_not_nil env[:body][:details]["trigger_time"]
       assert_not_nil env[:body][:details]["alert"]
       assert_not_nil env[:body][:details]["user_id"]
+      assert_not_nil env[:body][:details][:alert_link]
+      assert_nil env[:body][:details][:metric_link] # no metric_link for v2 alerts
       assert_equal "trigger", env[:body][:event_type]
       assert_equal "foo", env[:body][:incident_key]
       assert_equal 'Some alert name', env[:body][:description]


### PR DESCRIPTION
metric_link doesn't really apply to v2 alerts (since they can span multiple metrics).  So that's now only included for v1 alert payloads.  A link to the alert is now included in the details of the pd payload.
