### PR TITLE
Update notification paloads for new snapshots

### DIFF
--- a/lib/librato-services/helpers/snapshot_helpers.rb
+++ b/lib/librato-services/helpers/snapshot_helpers.rb
@@ -12,7 +12,10 @@ module Librato
             :snapshot => {
               :entity_name => "App API Requests",
               :entity_url => "https://metrics.librato.com/instruments/1234?duration=3600",
-              :image_url => "http://snapshots.librato.com/instruments/12345abcd.png"
+              :image_url => "http://snapshots.librato.com/instruments/12345abcd.png",
+              :user_email => "portal-dev@librato.com",
+              :subject => "Subject of API Requests",
+              :message => "Explanation of this snapshot"
             }
           }.with_indifferent_access
         end

--- a/lib/librato-services/helpers/snapshot_helpers.rb
+++ b/lib/librato-services/helpers/snapshot_helpers.rb
@@ -13,7 +13,10 @@ module Librato
               :entity_name => "App API Requests",
               :entity_url => "https://metrics.librato.com/instruments/1234?duration=3600",
               :image_url => "http://snapshots.librato.com/instruments/12345abcd.png",
-              :user_email => "portal-dev@librato.com",
+              :user => {
+                :email => "portal-dev@librato.com",
+                :full_name => "Librato User"
+              },
               :subject => "Subject of API Requests",
               :message => "Explanation of this snapshot"
             }

--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -35,11 +35,11 @@ class Service::Campfire < Service
     # because RACECARS :-/
     uri.gsub!(/\*$/, '%2A')
 
-    # Chart name isn't required, show URL if absent
     name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
+    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
 
     [
-      "#{name} #{uri} by #{snapshot[:user][:full_name] || snapshot[:user][:email]}",
+      "#{name}#{uri} by #{sender}",
       snapshot[:message],
       snapshot[:image_url]
     ].compact

--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -19,19 +19,30 @@ class Service::Campfire < Service
   def receive_snapshot
     raise_config_error unless receive_validate({})
 
+    speak_msgs(snapshot_message)
+  end
+
+  def snapshot_message
+    snapshot = payload[:snapshot]
+
     # Make sure that spaces in the URI's are encoded.
     # We can't just call URI.escape, because escaping
     # an escaped URI is not idempotent. It will re-escape
     # the '%' signs from the first escaping
-    uri = payload[:snapshot][:entity_url].gsub(/ /, '%20')
+    uri = snapshot[:entity_url].gsub(/ /, '%20')
 
     # Campfire can't handle URI's that end in an '*'
     # because RACECARS :-/
     uri.gsub!(/\*$/, '%2A')
 
-    # Send it!
-    speak_msgs(["%s: %s" % [payload[:snapshot][:entity_name], uri],
-                payload[:snapshot][:image_url]])
+    # Chart name isn't required, show URL if absent
+    name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
+
+    [
+      "#{name} #{uri} by #{snapshot[:user_email]}",
+      snapshot[:message],
+      snapshot[:image_url]
+    ].compact
   end
 
   def receive_alert_clear

--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -35,8 +35,8 @@ class Service::Campfire < Service
     # because RACECARS :-/
     uri.gsub!(/\*$/, '%2A')
 
-    name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
-    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
+    name = snapshot[:entity_name].blank? ? '' : "#{snapshot[:entity_name]}: "
+    sender = snapshot[:user][:full_name].blank? ? snapshot[:user][:email] : snapshot[:user][:full_name]
 
     [
       "#{name}#{uri} by #{sender}",

--- a/services/campfire.rb
+++ b/services/campfire.rb
@@ -39,7 +39,7 @@ class Service::Campfire < Service
     name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
 
     [
-      "#{name} #{uri} by #{snapshot[:user_email]}",
+      "#{name} #{uri} by #{snapshot[:user][:full_name] || snapshot[:user][:email]}",
       snapshot[:message],
       snapshot[:image_url]
     ].compact

--- a/services/flowdock.rb
+++ b/services/flowdock.rb
@@ -33,8 +33,8 @@ class Service::Flowdock < Service::Mail
   def snapshot_message
     snapshot = payload[:snapshot]
 
-    name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
-    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
+    name = snapshot[:entity_name].blank? ? '' : "#{snapshot[:entity_name]}: "
+    sender = snapshot[:user][:full_name].blank? ? snapshot[:user][:email] : snapshot[:user][:full_name]
 
     [
       "#{name}#{snapshot[:entity_url]} by #{sender}",

--- a/services/flowdock.rb
+++ b/services/flowdock.rb
@@ -32,9 +32,12 @@ class Service::Flowdock < Service::Mail
 
   def snapshot_message
     snapshot = payload[:snapshot]
+
     name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
+    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
+
     [
-      "#{name} #{snapshot[:entity_url]} by #{snapshot[:user][:full_name] || snapshot[:user][:email]}",
+      "#{name}#{snapshot[:entity_url]} by #{sender}",
       snapshot[:message],
       snapshot[:image_url]
     ].compact

--- a/services/flowdock.rb
+++ b/services/flowdock.rb
@@ -27,10 +27,17 @@ class Service::Flowdock < Service::Mail
   def receive_snapshot
     raise_config_error unless receive_validate({})
 
-    flowdock.push_to_chat(:content => "%s: %s" % [
-      payload[:snapshot][:entity_name],
-      payload[:snapshot][:entity_url]])
-    flowdock.push_to_chat(:content => payload[:snapshot][:image_url])
+    send_messages snapshot_message
+  end
+
+  def snapshot_message
+    snapshot = payload[:snapshot]
+    name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
+    [
+      "#{name} #{snapshot[:entity_url]} by #{snapshot[:user_email]}",
+      snapshot[:message],
+      snapshot[:image_url]
+    ].compact
   end
 
   def receive_alert
@@ -40,6 +47,10 @@ class Service::Flowdock < Service::Mail
       :subject => mail_message.subject,
       :content => mail_message.html_part.body,
       :link => payload_link(payload))
+  end
+
+  def send_messages(messages)
+    messages.each { |m| flowdock.push_to_chat(content: m) }
   end
 
   def flowdock

--- a/services/flowdock.rb
+++ b/services/flowdock.rb
@@ -34,7 +34,7 @@ class Service::Flowdock < Service::Mail
     snapshot = payload[:snapshot]
     name = snapshot[:entity_name] ? "#{snapshot[:entity_name]}: " : ''
     [
-      "#{name} #{snapshot[:entity_url]} by #{snapshot[:user_email]}",
+      "#{name} #{snapshot[:entity_url]} by #{snapshot[:user][:full_name] || snapshot[:user][:email]}",
       snapshot[:message],
       snapshot[:image_url]
     ].compact

--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -115,9 +115,9 @@ class Service::Hipchat < Service
   def snapshot_message
     snapshot = payload[:snapshot]
 
-    name = snapshot[:entity_name] || snapshot[:entity_url]
-    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
-    message = snapshot[:message] ? "<br/>#{snapshot[:message]}" : nil
+    name = snapshot[:entity_name].blank? ? snapshot[:entity_url] : snapshot[:entity_name]
+    sender = snapshot[:user][:full_name].blank? ? snapshot[:user][:email] : snapshot[:user][:full_name]
+    message = snapshot[:message].blank? ? nil : "<br/>#{snapshot[:message]}"
 
     [
       "<a href='#{snapshot[:entity_url]}'>#{name}</a> by #{sender}",

--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -113,12 +113,12 @@ class Service::Hipchat < Service
   end
 
   def snapshot_message
-    "%s: <a href=\"%s\">%s</a><br/><a href=\"%s\" target=\"_blank\"><img src=\"%s\"></img></a>" %
-      [payload[:snapshot][:entity_name],
-       payload[:snapshot][:entity_url],
-       payload[:snapshot][:entity_url],
-       payload[:snapshot][:image_url],
-       payload[:snapshot][:image_url]]
+    snapshot = payload[:snapshot]
+    [
+      "<a href='#{snapshot[:entity_url]}'>#{snapshot[:entity_name] || snapshot[:entity_url]}</a> by #{snapshot[:user_email]}",
+      snapshot[:message] ? "<br/>#{snapshot[:message]}" : nil,
+      "<br/><a href='#{snapshot[:image_url]}' target='_blank'><img src='#{snapshot[:image_url]}'></img></a>"
+    ].compact.join
   end
 
   def server_url

--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -115,7 +115,7 @@ class Service::Hipchat < Service
   def snapshot_message
     snapshot = payload[:snapshot]
     [
-      "<a href='#{snapshot[:entity_url]}'>#{snapshot[:entity_name] || snapshot[:entity_url]}</a> by #{snapshot[:user_email]}",
+      "<a href='#{snapshot[:entity_url]}'>#{snapshot[:entity_name] || snapshot[:entity_url]}</a> by #{snapshot[:user][:full_name] || snapshot[:user][:email]}",
       snapshot[:message] ? "<br/>#{snapshot[:message]}" : nil,
       "<br/><a href='#{snapshot[:image_url]}' target='_blank'><img src='#{snapshot[:image_url]}'></img></a>"
     ].compact.join

--- a/services/hipchat.rb
+++ b/services/hipchat.rb
@@ -114,9 +114,14 @@ class Service::Hipchat < Service
 
   def snapshot_message
     snapshot = payload[:snapshot]
+
+    name = snapshot[:entity_name] || snapshot[:entity_url]
+    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
+    message = snapshot[:message] ? "<br/>#{snapshot[:message]}" : nil
+
     [
-      "<a href='#{snapshot[:entity_url]}'>#{snapshot[:entity_name] || snapshot[:entity_url]}</a> by #{snapshot[:user][:full_name] || snapshot[:user][:email]}",
-      snapshot[:message] ? "<br/>#{snapshot[:message]}" : nil,
+      "<a href='#{snapshot[:entity_url]}'>#{name}</a> by #{sender}",
+      message,
       "<br/><a href='#{snapshot[:image_url]}' target='_blank'><img src='#{snapshot[:image_url]}'></img></a>"
     ].compact.join
   end

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -113,7 +113,7 @@ class Service::Slack < Service
           title: "<#{snapshot[:entity_url]}|#{name}> by #{sender}",
           fallback: "#{name} by #{sender}: #{snapshot[:image_url]}",
           text: "#{message}<#{snapshot[:image_url]}>",
-          mrkdwn_in: [:title],
+          mrkdwn_in: [:title, :text],
           color: "#0881AE"
         }
       ]

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -112,7 +112,7 @@ class Service::Slack < Service
         {
           title: "<#{snapshot[:entity_url]}|#{name}> by #{sender}",
           fallback: "#{name} by #{sender}: #{snapshot[:image_url]}",
-          text: "#{message}#{snapshot[:image_url]}",
+          text: "#{message}<#{snapshot[:image_url]}>",
           mrkdwn_in: [:title]
         }
       ]

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -113,7 +113,7 @@ class Service::Slack < Service
           title: "<#{snapshot[:entity_url]}|#{name}> by #{sender}",
           fallback: "#{name} by #{sender}: #{snapshot[:image_url]}",
           text: "#{message}#{snapshot[:image_url]}",
-          mrkdwn_in: [:title, :text]
+          mrkdwn_in: [:title]
         }
       ]
     }

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -107,16 +107,28 @@ class Service::Slack < Service
     sender = snapshot[:user][:full_name].blank? ? snapshot[:user][:email] : snapshot[:user][:full_name]
     message = snapshot[:message].blank? ? nil : "#{snapshot[:message]}\n"
 
+    # TODO: Switch to this data type when new Slack webhooks land
+    #data = {
+    #  attachments: [
+    #    {
+    #      title: "#{name} by #{sender}",
+    #      title_link: snapshot[:entity_url],
+    #      fallback: "#{name} by #{sender}: #{snapshot[:image_url]}",
+    #      text: "#{message}<#{snapshot[:image_url]}>",
+    #      mrkdwn_in: [:title, :text],
+    #      color: "#0881AE"
+    #    }
+    #  ]
+    #}
+
+    bytes = http_method(:head, snapshot[:image_url]).headers[:content_length] rescue 0
     data = {
-      attachments: [
-        {
-          title: "<#{snapshot[:entity_url]}|#{name}> by #{sender}",
-          fallback: "#{name} by #{sender}: #{snapshot[:image_url]}",
-          text: "#{message}<#{snapshot[:image_url]}>",
-          mrkdwn_in: [:title, :text],
-          color: "#0881AE"
-        }
-      ]
+      :inst_text    => "#{name} by #{sender}",
+      :inst_url     => snapshot[:entity_url],
+      :image_url    => snapshot[:image_url],
+      :image_width  => Librato::Services::Helpers::SnapshotHelpers::DEFAULT_SNAPSHOT_WIDTH,
+      :image_height => Librato::Services::Helpers::SnapshotHelpers::DEFAULT_SNAPSHOT_HEIGHT,
+      :image_bytes  => bytes
     }
 
     Yajl::Encoder.encode(data)

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -104,12 +104,13 @@ class Service::Slack < Service
     snapshot = payload[:snapshot]
 
     name = snapshot[:entity_name] || snapshot[:entity_url]
+    by = snapshot[:user][:full_name] || snapshot[:user][:email]
 
     data = {
       attachments: [
         {
-          title: "<#{snapshot[:entity_url]}|#{name}> by #{snapshot[:user_email]}",
-          fallback: "#{name} by #{snapshot[:user_email]} #{snapshot[:image_url]}",
+          title: "<#{snapshot[:entity_url]}|#{name}> by #{by}",
+          fallback: "#{name} by #{by} #{snapshot[:image_url]}",
           text: "#{snapshot[:message]}\n#{snapshot[:image_url]}",
           mrkdwn_in: [:title, :text]
         }

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -113,7 +113,8 @@ class Service::Slack < Service
           title: "<#{snapshot[:entity_url]}|#{name}> by #{sender}",
           fallback: "#{name} by #{sender}: #{snapshot[:image_url]}",
           text: "#{message}<#{snapshot[:image_url]}>",
-          mrkdwn_in: [:title]
+          mrkdwn_in: [:title],
+          color: "#0881AE"
         }
       ]
     }

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -104,14 +104,15 @@ class Service::Slack < Service
     snapshot = payload[:snapshot]
 
     name = snapshot[:entity_name] || snapshot[:entity_url]
-    by = snapshot[:user][:full_name] || snapshot[:user][:email]
+    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
+    message = snapshot[:message] ? "#{snapshot[:message]}\n" : nil
 
     data = {
       attachments: [
         {
-          title: "<#{snapshot[:entity_url]}|#{name}> by #{by}",
-          fallback: "#{name} by #{by} #{snapshot[:image_url]}",
-          text: "#{snapshot[:message]}\n#{snapshot[:image_url]}",
+          title: "<#{snapshot[:entity_url]}|#{name}> by #{sender}",
+          fallback: "#{name} by #{sender}: #{snapshot[:image_url]}",
+          text: "#{message}#{snapshot[:image_url]}",
           mrkdwn_in: [:title, :text]
         }
       ]

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -103,9 +103,9 @@ class Service::Slack < Service
   def snapshot_message
     snapshot = payload[:snapshot]
 
-    name = snapshot[:entity_name] || snapshot[:entity_url]
-    sender = snapshot[:user][:full_name] || snapshot[:user][:email]
-    message = snapshot[:message] ? "#{snapshot[:message]}\n" : nil
+    name = snapshot[:entity_name].blank? ? snapshot[:entity_url] : snapshot[:entity_name]
+    sender = snapshot[:user][:full_name].blank? ? snapshot[:user][:email] : snapshot[:user][:full_name]
+    message = snapshot[:message].blank? ? nil : "#{snapshot[:message]}\n"
 
     data = {
       attachments: [

--- a/test/campfire_test.rb
+++ b/test/campfire_test.rb
@@ -82,7 +82,7 @@ class CampfireTest < Librato::Services::TestCase
 
     assert_equal 1, svc.campfire.rooms.size
     assert_equal 'r', svc.campfire.rooms.first.name
-    assert_equal 2, svc.campfire.rooms.first.lines.size # summary
+    assert_equal 3, svc.campfire.rooms.first.lines.size # summary
     #assert_equal 1, svc.campfire.rooms.first.pastes.size # logs
   end
 

--- a/test/flowdock_test.rb
+++ b/test/flowdock_test.rb
@@ -55,10 +55,10 @@ class FlowdockTest < Librato::Services::TestCase
     svc.flowdock = MockFlowdock.new
     svc.receive_snapshot
 
-    assert_equal 2, svc.flowdock.chats.count
+    assert_equal 3, svc.flowdock.chats.count
     assert_equal 0, svc.flowdock.inbox.count
     assert_equal true, !!(svc.flowdock.chats[0][:content] =~ /#{snapshot_payload[:snapshot][:entity_name]}/)
-    assert_equal true, !!(svc.flowdock.chats[1][:content] =~ /http/)
+    assert_equal true, !!(svc.flowdock.chats[2][:content] =~ /http/)
   end
 
   def service(*args)

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -140,7 +140,8 @@ class SlackTest < Librato::Services::TestCase
       payload = JSON.parse(env[:body])
       original = snapshot_payload["snapshot"]
       assert(payload["attachments"][0]["title"].include?(original["entity_name"]))
-      assert(payload["attachments"][0]["title"].include?(original["user_email"]))
+      assert(payload["attachments"][0]["title"].include?(original["user"]["full_name"]))
+      assert(!payload["attachments"][0]["title"].include?(original["user"]["email"]))
       assert(payload["attachments"][0]["text"].include?(original["message"]))
       assert(payload["attachments"][0]["text"].include?(original["image_url"]))
       [200, {}, '']

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -135,21 +135,14 @@ class SlackTest < Librato::Services::TestCase
 
   def test_snapshots
     svc = service(:snapshot, @settings, snapshot_payload)
-    mock_bytes = '175000'
-
-    @stubs.head URI.parse(snapshot_payload["snapshot"]["image_url"]).path do |env|
-      [200, {'Content-Length' => mock_bytes}, '']
-    end
 
     @stubs.post @stub_url do |env|
       payload = JSON.parse(env[:body])
       original = snapshot_payload["snapshot"]
-      assert_equal(original["entity_name"], payload["inst_text"])
-      assert_equal(original["entity_url"], payload["inst_url"])
-      assert_equal(original["image_url"], payload["image_url"])
-      assert_equal(Librato::Services::Helpers::SnapshotHelpers::DEFAULT_SNAPSHOT_WIDTH, payload["image_width"])
-      assert_equal(Librato::Services::Helpers::SnapshotHelpers::DEFAULT_SNAPSHOT_HEIGHT, payload["image_height"])
-      assert_equal(mock_bytes, payload["image_bytes"])
+      assert(payload["attachments"][0]["title"].include?(original["entity_name"]))
+      assert(payload["attachments"][0]["title"].include?(original["user_email"]))
+      assert(payload["attachments"][0]["text"].include?(original["message"]))
+      assert(payload["attachments"][0]["text"].include?(original["image_url"]))
       [200, {}, '']
     end
 

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -139,11 +139,11 @@ class SlackTest < Librato::Services::TestCase
     @stubs.post @stub_url do |env|
       payload = JSON.parse(env[:body])
       original = snapshot_payload["snapshot"]
-      assert(payload["attachments"][0]["title"].include?(original["entity_name"]))
-      assert(payload["attachments"][0]["title"].include?(original["user"]["full_name"]))
-      assert(!payload["attachments"][0]["title"].include?(original["user"]["email"]))
-      assert(payload["attachments"][0]["text"].include?(original["message"]))
-      assert(payload["attachments"][0]["text"].include?(original["image_url"]))
+      assert(payload["inst_text"].include?(original["entity_name"]))
+      assert(payload["inst_text"].include?(original["user"]["full_name"]))
+      assert(!payload["inst_text"].include?(original["user"]["email"]))
+      #assert(payload["attachments"][0]["text"].include?(original["message"]))
+      assert(payload["image_url"].include?(original["image_url"]))
       [200, {}, '']
     end
 


### PR DESCRIPTION
## Examples

*Please note: Slack media unfurling isn't working yet, screenshots are of notifications with and without chart title, user name, snapshot message*

- [HipChat](https://cloud.githubusercontent.com/assets/33258/5728699/c7baf2aa-9b31-11e4-8f8e-76a85e01a933.png)
- [Slack](https://cloud.githubusercontent.com/assets/33258/5728698/c7b8ac0c-9b31-11e4-8d15-a9b0c7e9c450.png)
- [Campfire](https://cloud.githubusercontent.com/assets/33258/5728697/c7b8acca-9b31-11e4-96dd-b857f5bebee7.png)
- [Flowdock](https://cloud.githubusercontent.com/assets/33258/5728700/c7be4892-9b31-11e4-9e24-ab8aa2f9fb4e.png)