### PR TITLE
Expand Pagerduty payload.

### DIFF
--- a/lib/librato-services/helpers/alert_helpers.rb
+++ b/lib/librato-services/helpers/alert_helpers.rb
@@ -42,7 +42,8 @@ module Librato
           ::HashWithIndifferentAccess.new({
             user_id: 1,
             incident_key: "foo",
-            alert: {id: 123, name: "Some alert name", version: 2},
+            alert: {id: 123, name: "Some alert name", version: 2,
+                    description: "Verbose alert explanation", runbook_url: "http://runbooks.com/howtodoit"},
             auth: {email:"foo@example.com", annotations_token:"lol"},
             service_type: "campfire",
             event_type: "alert",

--- a/lib/librato-services/helpers/alert_helpers.rb
+++ b/lib/librato-services/helpers/alert_helpers.rb
@@ -42,8 +42,11 @@ module Librato
           ::HashWithIndifferentAccess.new({
             user_id: 1,
             incident_key: "foo",
-            alert: {id: 123, name: "Some alert name", version: 2,
-                    description: "Verbose alert explanation", runbook_url: "http://runbooks.com/howtodoit"},
+            alert: {id: 123,
+                    name: "Some alert name",
+                    version: 2,
+                    description: "Verbose alert explanation",
+                    runbook_url: "http://runbooks.com/howtodoit"},
             auth: {email:"foo@example.com", annotations_token:"lol"},
             service_type: "campfire",
             event_type: "alert",

--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -35,10 +35,19 @@ class Service::Pagerduty < Service
     }
 
     body[:event_type] = payload[:clear] ? "resolve" : "trigger"
+
     if payload[:alert][:version] == 1
       body[:details][:metric_url] = payload_link(payload)
     end
     body[:details][:alert_url] = alert_link(payload['alert']['id'])
+    unless payload['alert']['runbook_url'].blank?
+      body[:details][:runbook_url] = payload['alert']['runbook_url']
+    end
+
+    unless payload['alert']['description'].blank?
+      body[:details][:description] = payload['alert']['description']
+    end
+
     keys = [settings[:incident_key], payload[:incident_key]].compact
     if keys.size > 0
       body[:incident_key] = keys.join("-")

--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -36,9 +36,9 @@ class Service::Pagerduty < Service
 
     body[:event_type] = payload[:clear] ? "resolve" : "trigger"
     if payload[:alert][:version] == 1
-      body[:details][:metric_link] = payload_link(payload)
+      body[:details][:metric_url] = payload_link(payload)
     end
-    body[:details][:alert_link] = alert_link(payload['alert']['id'])
+    body[:details][:alert_url] = alert_link(payload['alert']['id'])
     keys = [settings[:incident_key], payload[:incident_key]].compact
     if keys.size > 0
       body[:incident_key] = keys.join("-")

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -71,6 +71,8 @@ class PagerdutyTest < Librato::Services::TestCase
       assert_not_nil env[:body][:details]["user_id"]
       assert_not_nil env[:body][:details][:alert_url]
       assert_nil env[:body][:details][:metric_url] # no metric_link for v2 alerts
+      assert_not_nil env[:body][:details][:description]
+      assert_not_nil env[:body][:details][:runbook_url]
       assert_equal "trigger", env[:body][:event_type]
       assert_equal "foo", env[:body][:incident_key]
       assert_equal 'Some alert name', env[:body][:description]

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -69,8 +69,8 @@ class PagerdutyTest < Librato::Services::TestCase
       assert_not_nil env[:body][:details]["trigger_time"]
       assert_not_nil env[:body][:details]["alert"]
       assert_not_nil env[:body][:details]["user_id"]
-      assert_not_nil env[:body][:details][:alert_link]
-      assert_nil env[:body][:details][:metric_link] # no metric_link for v2 alerts
+      assert_not_nil env[:body][:details][:alert_url]
+      assert_nil env[:body][:details][:metric_url] # no metric_link for v2 alerts
       assert_equal "trigger", env[:body][:event_type]
       assert_equal "foo", env[:body][:incident_key]
       assert_equal 'Some alert name', env[:body][:description]


### PR DESCRIPTION
This adds the alert description and runbook_url as top-level attributes of the Pagerduty payload. This means they will be accessible in the PD UI. I've also moved all URL based fields to the suffix "*_url".