### PR TITLE
Remove user_id from payload.

### DIFF
--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -22,7 +22,7 @@ class Service::Pagerduty < Service
     raise_config_error unless receive_validate({})
 
     pd_payload = {}
-    ['user_id', 'alert', 'trigger_time', 'conditions', 'violations'].each do |whitelisted|
+    ['alert', 'trigger_time', 'conditions', 'violations'].each do |whitelisted|
       pd_payload[whitelisted] = payload[whitelisted]
     end
     alert_name = payload['alert']['name']

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -68,7 +68,6 @@ class PagerdutyTest < Librato::Services::TestCase
       assert_not_nil env[:body][:details]["conditions"]
       assert_not_nil env[:body][:details]["trigger_time"]
       assert_not_nil env[:body][:details]["alert"]
-      assert_not_nil env[:body][:details]["user_id"]
       assert_not_nil env[:body][:details][:alert_url]
       assert_nil env[:body][:details][:metric_url] # no metric_link for v2 alerts
       assert_not_nil env[:body][:details][:description]
@@ -100,7 +99,6 @@ class PagerdutyTest < Librato::Services::TestCase
       assert_not_nil env[:body][:details]["conditions"]
       assert_not_nil env[:body][:details]["trigger_time"]
       assert_not_nil env[:body][:details]["alert"]
-      assert_not_nil env[:body][:details]["user_id"]
       assert_equal "resolve", env[:body][:event_type]
       assert_equal "foo", env[:body][:incident_key]
       assert_equal 'Some alert name', env[:body][:description]


### PR DESCRIPTION
For now, the integer user ID is not useful in the payload. May consider replacing with actual user email/name?