### PR TITLE
Allow spaces in the VictorOps routing key

### DIFF
--- a/services/victorops.rb
+++ b/services/victorops.rb
@@ -35,6 +35,7 @@ class Service::VictorOps < Service
 
       # Fire
       uri = uri_for_key(settings[:api_key])
+      puts "got uri: #{uri}"
       http_post(uri, body, headers)
     else
       stdout_logger "Only version 2 and greater alerts supported"
@@ -58,7 +59,7 @@ class Service::VictorOps < Service
 
   # Helpers
   def uri_for_key(key)
-    File.join("#{http_scheme}#{host}", integrations_path_for_key(key), (settings[:routing_key] || 'nil')).to_s
+    File.join("#{http_scheme}#{host}", integrations_path_for_key(key), URI::encode(settings[:routing_key] || 'nil')).to_s
   end
 
   def host; 'alert.victorops.com'; end

--- a/services/victorops.rb
+++ b/services/victorops.rb
@@ -35,7 +35,6 @@ class Service::VictorOps < Service
 
       # Fire
       uri = uri_for_key(settings[:api_key])
-      puts "got uri: #{uri}"
       http_post(uri, body, headers)
     else
       stdout_logger "Only version 2 and greater alerts supported"

--- a/test/victorops_test.rb
+++ b/test/victorops_test.rb
@@ -6,6 +6,7 @@ class VictorOpsTest < Librato::Services::TestCase
     @settings = { api_key: 'some_keys', routing_key: 'five' }
     @stubs = Faraday::Adapter::Test::Stubs.new do |stub|
       stub.post("/integrations/generic/20131114/alert/#{@settings[:api_key]}/#{@settings[:routing_key]}"){ |env| [200, {}, ''] }
+      stub.post("/integrations/generic/20131114/alert/#{@settings[:api_key]}/has%20space"){ |env| [200, {}, ''] }
       stub.post("/integrations/generic/20131114/alert/#{@settings[:api_key]}/nil"){ |env| [200, {}, ''] }
     end
   end
@@ -21,6 +22,12 @@ class VictorOpsTest < Librato::Services::TestCase
     errors = {}
     assert !svc.receive_validate(errors), 'Validation was true'
     assert_equal 1, errors.length
+  end
+
+  def test_has_space_in_routing_key
+    svc = service(:alert, {"api_key" => @settings[:api_key], "routing_key" => "has space"}.with_indifferent_access, new_alert_payload)
+    resp = svc.receive_alert
+    assert_equal 200, resp.status
   end
 
   def test_alerts


### PR DESCRIPTION
It wasn't URI-encoding the routing key, which would cause URI parsing to fail.