### PR TITLE
Add service and test for BigPanda

### DIFF
--- a/services/big_panda.rb
+++ b/services/big_panda.rb
@@ -1,0 +1,65 @@
+# See https://www.bigpanda.io/docs/integrations/index.html#alerts-rest-api
+class Service::BigPanda < Service
+  def receive_validate(errors = {})
+    success = true
+    [:app_key, :token].each do |k|
+      if settings[k].to_s.empty?
+        errors[k] = 'Is required'
+        success = false
+      end
+    end
+    success
+  end
+
+  def receive_alert
+    raise_config_error unless receive_validate({})
+    send_alert(body.merge('status' => 'critical'))
+  end
+
+  def receive_alert_clear
+    raise_config_error unless receive_validate({})
+    send_alert(body.merge('status' => 'ok'))
+  end
+
+  def send_alert(body)
+    url = 'https://api.bigpanda.io/data/v2/alerts'
+    begin
+      http_post(url, body, headers)
+    rescue Faraday::Error::ConnectionFailed
+      log("Connection failed for url: #{url} for payload: #{payload.inspect}")
+    end
+  end
+
+  def body
+    body = {
+      'app_key' => settings[:app_key],
+      'service' => 'Librato',
+      'check' => payload['alert']['name'],
+      'timestamp' => payload['trigger_time']
+    }
+
+    body['description'] = payload['alert']['description'] if payload['alert']['description']
+    body['runbook_url'] = payload['alert']['runbook_url'] if payload['alert']['runbook_url']
+
+    output = Librato::Services::Output.new(payload)
+    violations = []
+    payload['violations'].each do |key, metric|
+      metric.each {|v| violations << output.format_measurement(v) }
+    end
+    body['violations'] = violations.join('\n')
+    body
+  end
+
+  def headers
+    {'Authorization' => "Bearer #{settings[:token]}",
+     'Content-Type'  => 'application/json'}
+  end
+
+  def log(msg)
+    if defined?(Rails)
+      Rails.logger.info(msg)
+    else
+      puts(msg)
+    end
+  end
+end

--- a/test/big_panda_test.rb
+++ b/test/big_panda_test.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../helper', __FILE__)
+
+class BigPandaTest < Librato::Services::TestCase
+  def setup
+    @settings = {:app_key => 'my api key', :token => 'my token', :application => 'webapp'}
+    @stub_url = URI.parse('https://api.bigpanda.io/data/v2/alerts').request_uri
+    @stubs = Faraday::Adapter::Test::Stubs.new
+  end
+
+  def test_v2_alert
+    payload = new_alert_payload.dup
+    svc = service(:alert, @settings, payload)
+    @stubs.post @stub_url do |env|
+      [200, {}, '']
+    end
+    svc.receive_alert
+  end
+
+  def service(*args)
+    super Service::BigPanda, *args
+  end
+end


### PR DESCRIPTION
See https://www.bigpanda.io/docs/integrations/index.html?v=v2.4.0-5-g018f1c2#alerts-rest-api for available fields

Notes:

* Status for all alerts is "critical". Should this be configurable in the alert by the user (perhaps a user would want one alert for "warning" and one for "critical")?
* Uses `Librato::Services::Output` to attach a human-readable message to the alert. Is more detail desirable?
* Does the test test what we need to test?