### PR TITLE
Add account information to serveral services

### DIFF
--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -26,6 +26,7 @@ module Librato
         @alert = payload[:alert]
         @clear = payload[:clear]
         @trigger_time = payload[:trigger_time]
+        @auth = payload[:auth] || {}
       end
 
       def html
@@ -52,6 +53,9 @@ module Librato
         result_array = ["# Alert #{@alert[:name]} has triggered!\n"]
         if @alert[:description]
           result_array << "Description: #{@alert[:description]}\n"
+        end
+        if @auth[:email]
+          result_array << "Account: #{@auth[:email]}\n"
         end
         result_array << "Link: #{alert_link(@alert[:id])}\n"
         @violations.each do |source, measurements|
@@ -81,6 +85,9 @@ module Librato
         end
         if @alert[:description]
           lines << "Description: #{@alert[:description]}\n"
+        end
+        if @auth[:email]
+          lines << "Account: #{@auth[:email]}\n"
         end
         lines << "Link: #{alert_link(@alert[:id])}\n"
         lines.join("\n")

--- a/services/opsgenie.rb
+++ b/services/opsgenie.rb
@@ -17,11 +17,18 @@ class Service::OpsGenie < Service
     success
   end
 
+  def account_email
+    if payload['auth']
+      payload['auth']['email']
+    end
+  end
+
   def receive_alert_clear
     raise_config_error unless receive_validate({})
 
     result = {
         :alert => payload['alert'],
+        :account => account_email,
         :trigger_time => payload['trigger_time'],
         :clear => "normal"
     }
@@ -34,6 +41,7 @@ class Service::OpsGenie < Service
     if payload[:alert][:version] == 2
       result = {
           :alert => payload['alert'],
+          :account => account_email,
           :trigger_time => payload['trigger_time'],
           :conditions => payload['conditions'],
           :violations => payload['violations']

--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -18,12 +18,21 @@ class Service::Pagerduty < Service
     receive_alert
   end
 
+  def account_email
+    if payload['auth']
+      payload['auth']['email']
+    end
+  end
+
   def receive_alert
     raise_config_error unless receive_validate({})
 
     pd_payload = {}
     ['alert', 'trigger_time', 'conditions', 'violations'].each do |whitelisted|
       pd_payload[whitelisted] = payload[whitelisted]
+    end
+    if email = account_email
+      pd_payload['account'] = email
     end
     alert_name = payload['alert']['name']
     description = alert_name.blank? ? settings[:description] : alert_name

--- a/services/webhook.rb
+++ b/services/webhook.rb
@@ -21,11 +21,18 @@ class Service::Webhook < Service
     return true
   end
 
+  def account_email
+    if payload['auth']
+      payload['auth']['email']
+    end
+  end
+
   def receive_alert_clear
     raise_config_error unless receive_validate({})
     uri = URI.parse(settings[:url])
     result = {
       :alert => payload['alert'],
+      :account => account_email,
       :trigger_time => payload['trigger_time'],
       :clear => "normal"
     }
@@ -39,6 +46,7 @@ class Service::Webhook < Service
     if payload[:alert][:version] == 2
       result = {
         :alert => payload['alert'],
+        :account => account_email,
         :trigger_time => payload['trigger_time'],
         :conditions => payload['conditions'],
         :violations => payload['violations']

--- a/test/webhook_test.rb
+++ b/test/webhook_test.rb
@@ -55,10 +55,11 @@ class WebhookTest < Librato::Services::TestCase
 
     @stubs.post "#{path}" do |env|
       payload = JSON.parse(env[:body][:payload])
-      assert_equal ["alert", "conditions", "trigger_time", "violations"], payload.keys.sort
+      assert_equal ["account", "alert", "conditions", "trigger_time", "violations"], payload.keys.sort
       assert_equal 123, payload['alert']['id']
       assert_equal 'Some alert name', payload['alert']['name']
       assert_equal 1, payload['conditions'].length
+      assert_equal "foo@example.com", payload['account']
       violations = payload['violations']
       foo_bar_violations = violations['foo.bar']
       assert_equal 1, foo_bar_violations.length


### PR DESCRIPTION
Services include

* email
* victorops
* opsgenie
* pagerduty
* webhook

In addition to other services that use rendered markdown format.

ticket: https://app.asana.com/0/18095599909888/24339696382393

cc @akahn @obfuscurity 

Some screenshots:

![email](https://cloud.githubusercontent.com/assets/596076/8011709/cd2a5d44-0b6f-11e5-8213-325e828509b5.png)

![pagerduty](https://cloud.githubusercontent.com/assets/596076/8011711/d233726c-0b6f-11e5-894d-cf792436424d.png)

![victorops](https://cloud.githubusercontent.com/assets/596076/8011717/d79a4a6e-0b6f-11e5-9255-c9bd1c35c044.png)