### PR TITLE
Slack clear timestamps should match alerts

### DIFF
--- a/services/slack.rb
+++ b/services/slack.rb
@@ -24,7 +24,7 @@ class Service::Slack < Service
   def v2_alert_result
     data = Librato::Services::Output.new(payload)
     runbook_url = data.alert[:runbook_url]
-    trigger_time_utc = DateTime.strptime(Time.at(data.trigger_time).utc.to_s, "%s").strftime("%a, %b %e %Y at %H:%M:%S UTC")
+    trigger_time_utc = DateTime.strptime(data.trigger_time.to_s, "%s").strftime("%a, %b %e %Y at %H:%M:%S UTC")
     if data.clear
       text = case data.clear
              when "manual"

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -24,7 +24,7 @@ class Service::Slack < Service
   def v2_alert_result
     data = Librato::Services::Output.new(payload)
     runbook_url = data.alert[:runbook_url]
-    trigger_time_utc = Time.at(data.trigger_time).utc
+    trigger_time_utc = DateTime.strptime(Time.at(data.trigger_time).utc.to_s, "%s").strftime("%a, %b %e %Y at %H:%M:%S UTC")
     if data.clear
       text = case data.clear
              when "manual"

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -54,8 +54,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at 1970-05-23 14:32:03 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' has cleared at 1970-05-23 14:32:03 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert
@@ -72,8 +72,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at 1970-05-23 14:32:03 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' has cleared at 1970-05-23 14:32:03 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert
@@ -90,8 +90,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was manually cleared at 1970-05-23 14:32:03 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' was manually cleared at 1970-05-23 14:32:03 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was manually cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' was manually cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert
@@ -108,8 +108,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was automatically cleared at 1970-05-23 14:32:03 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' was automatically cleared at 1970-05-23 14:32:03 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was automatically cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' was automatically cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert

--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -54,8 +54,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' has cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert
@@ -72,8 +72,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' has cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> has cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' has cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert
@@ -90,8 +90,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was manually cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' was manually cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was manually cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' was manually cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert
@@ -108,8 +108,8 @@ class SlackTest < Librato::Services::TestCase
       attachment = payload["attachments"][0]
       assert_equal(["color", "fallback", "text"], attachment.keys.sort)
       assert_nil(payload["text"])
-      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was automatically cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["text"]
-      assert_equal "Alert 'Some alert name' was automatically cleared at Thu, Jan  1 1970 at 00:32:50 UTC", attachment["fallback"]
+      assert_equal "Alert <https://metrics.librato.com/alerts/123|Some alert name> was automatically cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["text"]
+      assert_equal "Alert 'Some alert name' was automatically cleared at Sat, May 23 1970 at 14:32:03 UTC", attachment["fallback"]
       [200, {}, '']
     end
     svc.receive_alert


### PR DESCRIPTION
Fixes the mismatched timestamp formats as reported by @pcn in #115.

![screen shot 2015-06-26 at 12 23 23 pm](https://cloud.githubusercontent.com/assets/494338/8382110/51c0ad44-1bfe-11e5-8e84-36085402b36f.png)

/cc @akahn @collinvandyck 