### PR TITLE
Simple email address format validation

### DIFF
--- a/services/mail.rb
+++ b/services/mail.rb
@@ -19,6 +19,10 @@ class Service::Mail < Service
         errors[:addresses] = "Must be a comma-separated string"
         return false
       end
+      if address.strip !~ /@/
+        errors[:addresses] = "Not a valid email address"
+        return false
+      end
     end
     true
   end

--- a/services/mail.rb
+++ b/services/mail.rb
@@ -20,7 +20,7 @@ class Service::Mail < Service
         return false
       end
       if address.strip !~ /@/
-        errors[:addresses] = "Not a valid email address"
+        errors[:addresses] = "Not a valid email address: #{address}"
         return false
       end
     end

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -38,6 +38,12 @@ class MailTest < Librato::Services::TestCase
     assert(!svc.receive_validate(errors))
     assert_equal(1, errors.length)
     assert(errors[:addresses])
+
+    svc = service(:alert, { :addresses => 'fred@barn.com, http://foo.com/' }, alert_payload)
+    errors = {}
+    assert(!svc.receive_validate(errors))
+    assert_equal(1, errors.length)
+    assert(errors[:addresses])
   end
 
   def test_new_alerts


### PR DESCRIPTION
The email RFCs are notoriously flexible, but this will at least catch some basic mistakes, e.g. trying to paste an HTTP URL in the field (at least, one without auth).