### PR TITLE
Stop uploading to RubyGems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,6 @@ t = Jeweler::Tasks.new do |gem|
   # dependencies defined in Gemfile
 end
 jeweler = t.jeweler
-Jeweler::RubygemsDotOrgTasks.new
 
 #
 # XXX: Rake does not provide a way to remove a task


### PR DESCRIPTION
We're including librato-services via git url now, so no need to upload the gem to RubyGems anymore. Removing this line should do the trick. The preceding line takes care of the actual gem creation afaict. /cc @akahn @mheffner @chancefeick 