### PR TITLE
Check for protocol in Webhook URLs

### DIFF
--- a/services/webhook.rb
+++ b/services/webhook.rb
@@ -18,6 +18,12 @@ class Service::Webhook < Service
       return false
     end
 
+    # Catches bare hostnames or IPs such as www.example.com or 192.0.2.0
+    if !uri.scheme
+      errors[:url] = 'Is missing protocol'
+      return false
+    end
+
     return true
   end
 

--- a/test/webhook_test.rb
+++ b/test/webhook_test.rb
@@ -22,6 +22,12 @@ class WebhookTest < Librato::Services::TestCase
     assert(!svc.receive_validate(errors))
     assert_equal(1, errors.length)
     assert(!errors[:url].nil?)
+
+    svc = service(:alert, {:url => "example.com/foo"}, alert_payload)
+    errors = {}
+    assert(!svc.receive_validate(errors))
+    assert_equal(1, errors.length)
+    assert(!errors[:url].nil?)
   end
 
   def test_alerts_multiple_measurements


### PR DESCRIPTION
This prevents an error when a user submits a webhook URL without a
protocol such as www.example.com or 192.0.2.0.