### PR TITLE
Format decimal places of violations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,3 +143,6 @@ DEPENDENCIES
   tinder (~> 1.9)
   yajl-ruby (~> 1.1)
   yard (~> 0.8)
+
+BUNDLED WITH
+   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,3 @@ DEPENDENCIES
   tinder (~> 1.9)
   yajl-ruby (~> 1.1)
   yard (~> 0.8)
-
-BUNDLED WITH
-   1.10.5

--- a/lib/librato-services/numbers.rb
+++ b/lib/librato-services/numbers.rb
@@ -1,0 +1,35 @@
+module Librato
+  module Services
+    class Numbers
+      def self.format_for_threshold(threshold, number, tolerance=2)
+
+        threshold_decimals = number_decimal_places(threshold)
+        number_decimals = number_decimal_places(number)
+
+        if !threshold_decimals || !number_decimals
+          return number
+        end
+
+        if (number_decimals - tolerance) <= threshold_decimals
+          return number
+        end
+
+        # here we have more decimals in the number than the threshold
+        # number:    3.14159
+        # threshold: 3.14
+
+        factor = (10**(threshold_decimals+tolerance)).to_f
+        (number * factor).truncate / factor
+      end
+
+      def self.number_decimal_places(number)
+        segments = number.to_s.split('.')
+        if segments.length != 2
+          return 0
+        end
+        segments[1].length
+      end
+    end
+  end
+end
+

--- a/lib/librato-services/numbers.rb
+++ b/lib/librato-services/numbers.rb
@@ -2,7 +2,6 @@ module Librato
   module Services
     class Numbers
       def self.format_for_threshold(threshold, number, tolerance=2)
-
         threshold_decimals = number_decimal_places(threshold)
         number_decimals = number_decimal_places(number)
 

--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -1,5 +1,6 @@
 require 'redcarpet'
 require 'helpers/alert_helpers'
+require 'lib/librato-services/numbers'
 
 # TODO
 # This has grown to the point where it may be worth generating an Alert
@@ -107,7 +108,10 @@ module Librato
         if condition[:type] == "absent"
           "absent for #{condition[:duration]} seconds"
         else
-          "#{condition[:type]} threshold #{threshold(condition, measurement)} with value #{measurement[:value]}"
+          threshold_value = condition[:threshold]
+          actual_value = measurement[:value]
+          formatted_value = Librato::Services::Numbers.format_for_threshold(threshold_value, actual_value)
+          "#{condition[:type]} threshold #{threshold(condition,measurement)} with value #{formatted_value}"
         end
       end
 

--- a/test/numbers_test.rb
+++ b/test/numbers_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../helper', __FILE__)
+require 'lib/librato-services/numbers'
+
+class NumbersTest < Test::Unit::TestCase
+  Numbers = Librato::Services::Numbers
+
+  def format(threshold, number, tolerance=2)
+    Librato::Services::Numbers.format_for_threshold(threshold,number,tolerance)
+  end
+
+  #def test_does_not_change
+    #assert format(10, 10.53) == 10.53
+    #assert format(10.53, 10.53) == 10.53
+  #end
+
+  def test_changes
+    assert_equal 10.5312, format(10.53, 10.5312345)
+    assert_equal 10.53, format(10, 10.5312345)
+    assert_equal 0.53, format(0, 0.5312345)
+    assert_equal 0.5312, format(0.12, 0.5312345)
+  end
+
+
+end

--- a/test/numbers_test.rb
+++ b/test/numbers_test.rb
@@ -18,6 +18,7 @@ class NumbersTest < Test::Unit::TestCase
     assert_equal 10.53, format(10, 10.5312345)
     assert_equal 0.53, format(0, 0.5312345)
     assert_equal 0.5312, format(0.12, 0.5312345)
+    assert_equal 100, format(10, 100)
   end
 
 

--- a/test/numbers_test.rb
+++ b/test/numbers_test.rb
@@ -8,10 +8,10 @@ class NumbersTest < Test::Unit::TestCase
     Librato::Services::Numbers.format_for_threshold(threshold,number,tolerance)
   end
 
-  #def test_does_not_change
-    #assert format(10, 10.53) == 10.53
-    #assert format(10.53, 10.53) == 10.53
-  #end
+  def test_does_not_change
+    assert format(10, 10.53) == 10.53
+    assert format(10.53, 10.53) == 10.53
+  end
 
   def test_changes
     assert_equal 10.5312, format(10.53, 10.5312345)

--- a/test/output_test.rb
+++ b/test/output_test.rb
@@ -75,6 +75,7 @@ EOF
     assert_equal(expected, output.markdown)
   end
 
+  # use decimals in threshold and value to test the formatting of decimal places
   def test_simple_alert
     payload = {
       alert: {id: 123, name: "Some alert name", version: 2},
@@ -82,10 +83,10 @@ EOF
       service_type: "campfire",
       event_type: "alert",
       trigger_time: 12321123,
-      conditions: [{type: "above", threshold: 10, id: 1}],
+      conditions: [{type: "above", threshold: 10.5, id: 1}],
       violations: {
         "foo.bar" => [{
-          metric: "metric.name", value: 100, recorded_at: 1389391083,
+          metric: "metric.name", value: 100.12345, recorded_at: 1389391083,
           condition_violated: 1
         }]
       }
@@ -97,7 +98,7 @@ EOF
 Link: https://metrics.librato.com/alerts/123
 
 Source `foo.bar`:
-* metric `metric.name` was above threshold 10 with value 100 recorded at Fri, Jan 10 2014 at 21:58:03 UTC
+* metric `metric.name` was above threshold 10.5 with value 100.123 recorded at Fri, Jan 10 2014 at 21:58:03 UTC
 EOF
     assert_equal(expected, output.markdown)
   end


### PR DESCRIPTION
Currently, in the event where a notifications gets rendered for:

threshold: `100.50`
violation: `200.1234567890`

It will output the full number of the violation: `200.1234567890`

This changeset alters this behavior by formatting the violation two decimal places past the resolution of the threshold.  So for the same scenario, it will format the number of the violation as `200.1234`.

This should help with making our formatted notifications easier to read.