### PR TITLE
Ignore .ruby-version and .ruby-gemset files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ doc
 # jeweler generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored
@@ -51,3 +51,6 @@ pkg
 log/newrelic*
 /payloads
 /*.gem
+
+/.ruby-version
+/.ruby-gemset

--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,4 @@ log/newrelic*
 /payloads
 /*.gem
 
-/.ruby-version
 /.ruby-gemset


### PR DESCRIPTION
Some of the dependancies require a certain version of ruby (e.g. eventmachine). This could be related to an issue specific to a local machine but, either way, we shouldn't include these two files in source control.