### PR TITLE
Provide payload 'clear' value for SNS, Webhook and Opsgenie services and 'incident_key' for SNS

### DIFF
--- a/lib/librato-services/helpers/alert_helpers.rb
+++ b/lib/librato-services/helpers/alert_helpers.rb
@@ -62,6 +62,18 @@ module Librato
           })
         end
 
+        def self.sample_alert_clear_payload(clear_type)
+          ::HashWithIndifferentAccess.new(
+            {
+              incident_key: "foo",
+              alert: { id: 123,
+                       name: "Some alert name" },
+              trigger_time: 12321123,
+              :clear => clear_type
+            }
+          )
+        end
+
         def get_measurements(body)
           measurements = body['measurements'] || []
           measurements << body['measurement']

--- a/services/opsgenie.rb
+++ b/services/opsgenie.rb
@@ -30,7 +30,7 @@ class Service::OpsGenie < Service
         :alert => payload['alert'],
         :account => account_email,
         :trigger_time => payload['trigger_time'],
-        :clear => "normal"
+        :clear => payload['clear']
     }
     post_it(result, false)
   end

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -32,8 +32,9 @@ class Service::SNS < Service
     msg = {
       :alert => payload['alert'],
       :trigger_time => payload['trigger_time'],
-      :clear => "normal"
+      :clear => payload['clear'],
     }
+    msg[:incident_key] = payload['incident_key'] if payload.key?('incident_key')
     publish_message(msg)
   end
 
@@ -48,6 +49,7 @@ class Service::SNS < Service
         :violations => payload['violations'],
         :triggered_by_user_test => payload['triggered_by_user_test']
       }
+      msg[:incident_key] = payload['incident_key'] if payload.key?('incident_key')
     else
       measurements = get_measurements(payload)[0..19]
       msg = {

--- a/services/webhook.rb
+++ b/services/webhook.rb
@@ -40,7 +40,7 @@ class Service::Webhook < Service
       :alert => payload['alert'],
       :account => account_email,
       :trigger_time => payload['trigger_time'],
-      :clear => "normal"
+      :clear => payload['clear']
     }
     post_it(uri, result)
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -45,6 +45,11 @@ class Librato::Services::TestCase < Test::Unit::TestCase
     Librato::Services::Helpers::AlertHelpers.sample_alert_payload
   end
 
+  # Valid clear types : normal, auto, manual, unknown
+  def alert_clear_payload(clear_type = 'normal')
+    Librato::Services::Helpers::AlertHelpers.sample_alert_clear_payload(clear_type)
+  end
+
   def snapshot_payload
     Librato::Services::Helpers::SnapshotHelpers.sample_snapshot_payload
   end

--- a/test/opsgenie_test.rb
+++ b/test/opsgenie_test.rb
@@ -40,6 +40,17 @@ class OpsGenieTest < Librato::Services::TestCase
     svc.receive_alert
   end
 
+  def test_receive_alert_clear
+    payload = alert_clear_payload
+    svc = service(:alert, @settings, payload)
+    @stubs.post @stub_url do |env|
+      payload = JSON.parse(env[:body][:payload])
+      assert_equal('normal', payload['clear'])
+      [200, {}, '']
+    end
+    svc.receive_alert_clear
+  end
+
   def service(*args)
     super Service::OpsGenie, *args
   end

--- a/test/sns_test.rb
+++ b/test/sns_test.rb
@@ -119,12 +119,12 @@ class SNSTest < Librato::Services::TestCase
   def test_receive_clear_manual
     svc = service(:alert, default_setting, alert_clear_payload('manual'))
     expect(svc).to receive(:publish_message).once.with(hash_including(
-                                                         {
-                                                           alert: { id: 123, name: 'Some alert name' },
-                                                           trigger_time: 12321123,
-                                                           clear: 'manual',
-                                                           incident_key: 'foo'
-                                                         }))
+      {
+        alert: { id: 123, name: 'Some alert name' },
+        trigger_time: 12321123,
+        clear: 'manual',
+        incident_key: 'foo'
+      }))
 
     svc.receive_alert_clear
   end

--- a/test/sns_test.rb
+++ b/test/sns_test.rb
@@ -103,14 +103,28 @@ class SNSTest < Librato::Services::TestCase
     svc.receive_alert
   end
 
-  def test_receive_clear
-    svc = service(:alert, default_setting, alert_payload)
+  def test_receive_clear_normal
+    svc = service(:alert, default_setting, alert_clear_payload)
     expect(svc).to receive(:publish_message).once.with(hash_including(
       {
-        alert: { id: 12345, name: '' },
-        trigger_time: 1321311840,
-        clear: 'normal'
+        alert: { id: 123, name: 'Some alert name' },
+        trigger_time: 12321123,
+        clear: 'normal',
+        incident_key: 'foo'
       }))
+
+    svc.receive_alert_clear
+  end
+
+  def test_receive_clear_manual
+    svc = service(:alert, default_setting, alert_clear_payload('manual'))
+    expect(svc).to receive(:publish_message).once.with(hash_including(
+                                                         {
+                                                           alert: { id: 123, name: 'Some alert name' },
+                                                           trigger_time: 12321123,
+                                                           clear: 'manual',
+                                                           incident_key: 'foo'
+                                                         }))
 
     svc.receive_alert_clear
   end
@@ -131,7 +145,8 @@ class SNSTest < Librato::Services::TestCase
         violations: {
           "foo.bar" => [{ metric: 'metric.name', value: 100, recorded_at: 1389391083, condition_violated: 1 }]
         },
-        triggered_by_user_test: false
+        triggered_by_user_test: false,
+        incident_key: 'foo'
       }))
 
     svc.receive_alert

--- a/test/webhook_test.rb
+++ b/test/webhook_test.rb
@@ -93,6 +93,21 @@ class WebhookTest < Librato::Services::TestCase
     svc.receive_alert
   end
 
+  def test_alert_clear_trigger
+    path = "/post_path.json"
+    url = "http://localhost#{path}"
+    payload = alert_clear_payload
+    svc = service(:alert, { :url => url }, payload)
+
+    @stubs.post "#{path}" do |env|
+      payload = JSON.parse(env[:body][:payload])
+      assert_equal 'normal', payload['clear']
+      [200, {}, '']
+    end
+
+    svc.receive_alert_clear
+  end
+
   def service(*args)
     super Service::Webhook, *args
   end


### PR DESCRIPTION
I originally planned to add it only for SNS, but after seeing Issue #132, I decided to apply it to Webhook and Opsgenie as well. Please let me know if I should do separate pulls requests.

This includes:
* Added a test helper for alert clear payload. It would be great if you could review that this is the actual payload provided by Librato when running in production. 
* SNS, Webhook and Opsgenie now extract the 'clear' value out of the payload instead of hardcoding to 'normal'. 
* SNS service now provides the 'incident_key'. To be honest, I am unsure about this one as it is completely undocumented at the exception of the PagerDuty and VictorOps integration. If the 'incident_key' value is unique for every combination of alert trigger/clear, then it would be really useful for the SNS integration. In any cases, I don't see any harm in publishing more information as part of the SNS message.
