### PR TITLE
Hotfix/sns-sms

### DIFF
--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -144,9 +144,25 @@ module Librato
       end
 
       def sms_message
+        if valid_sms?
+          violations_message
+        else
+          truncated_violations_message
+        end
+      end
+
+      def valid_sms?
+        violations_message.length <= 140
+      end
+
+      def violations_message
         violations.flat_map do |source, measurements|
           measurements.map { |measurement| format_measurement(measurement, source) }
         end.join('. ')
+      end
+
+      def truncated_violations_message
+        "#{violations_message[0..136]}..."
       end
 
       class << self

--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -146,7 +146,7 @@ module Librato
       def sms_message
         violations.flat_map do |source, measurements|
           measurements.map { |measurement| format_measurement(measurement, source) }
-        end.join(". ") if violations
+        end.join('. ')
       end
 
       class << self

--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -143,6 +143,12 @@ module Librato
         end
       end
 
+      def sms_message
+        violations.flat_map do |source, measurements|
+          measurements.map { |measurement| format_measurement(measurement, source) }
+        end.join(". ") if violations
+      end
+
       class << self
         def renderer
           @renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML, lax_spacing: true, no_intra_emphasis: true)

--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -1,6 +1,7 @@
 require 'redcarpet'
 require 'helpers/alert_helpers'
 require 'lib/librato-services/numbers'
+require 'active_support/core_ext/string/filters.rb'
 
 # TODO
 # This has grown to the point where it may be worth generating an Alert
@@ -147,7 +148,7 @@ module Librato
         if valid_sms?
           violations_message
         else
-          truncated_violations_message
+          violations_message.truncate(140)
         end
       end
 
@@ -159,10 +160,6 @@ module Librato
         violations.flat_map do |source, measurements|
           measurements.map { |measurement| format_measurement(measurement, source) }
         end.join('. ')
-      end
-
-      def truncated_violations_message
-        "#{violations_message[0..136]}..."
       end
 
       class << self

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -78,9 +78,11 @@ class Service::SNS < Service
       :default => msg.to_json
     }
 
-    json.tap do
-      json[:sms] = Librato::Services::Output.new(payload).sms_message if payload[:alert][:version] == 2
-    end.to_json
+    if payload[:alert][:version] == 2
+      json[:sms] = Librato::Services::Output.new(payload).sms_message
+    end
+
+    json.to_json
   end
 
   def region

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -63,7 +63,7 @@ class Service::SNS < Service
   end
 
   def publish_message(msg)
-    sns.publish(topic_arn: topic_arn, message: msg.to_json)
+    sns.publish(topic_arn: topic_arn, message: json_message_generator_for(msg), message_structure: 'json')
   rescue Aws::SNS::Errors::SignatureDoesNotMatch
     raise_config_error 'Authentication failed - incorrect access key id or access key secret'
   rescue Aws::SNS::Errors::AuthorizationError
@@ -71,6 +71,13 @@ class Service::SNS < Service
                        'on the topic and that the topic arn is correct'
   rescue Aws::SNS::Errors::ServiceError => e
     raise_error e.message
+  end
+
+  def json_message_generator_for(msg)
+    {
+      :default => msg.to_json,
+      :sms => Librato::Services::Output.new(payload).sms_message
+    }.to_json
   end
 
   def region

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -74,10 +74,13 @@ class Service::SNS < Service
   end
 
   def json_message_generator_for(msg)
-    {
-      :default => msg.to_json,
-      :sms => Librato::Services::Output.new(payload).sms_message
-    }.to_json
+    json = {
+      :default => msg.to_json
+    }
+
+    json.tap do
+      json[:sms] = Librato::Services::Output.new(payload).sms_message if payload[:alert][:version] == 2
+    end.to_json
   end
 
   def region

--- a/test/output_test.rb
+++ b/test/output_test.rb
@@ -291,4 +291,36 @@ EOF
     assert_match('metric `metric.name` from `foo.bar`', output.sms_message)
   end
 
+  def test_valid_sms
+    payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
+    output = Librato::Services::Output.new(payload)
+
+    assert_equal(true, output.valid_sms?)
+  end
+
+  def test_invalid_sms
+    payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
+    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..160-1]
+    output = Librato::Services::Output.new(payload)
+
+    assert_equal(false, output.valid_sms?)
+  end
+
+  def test_violations_message
+    payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
+    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..160-1]
+    output = Librato::Services::Output.new(payload)
+
+    assert_equal(true, output.violations_message.length >= 140)
+  end
+
+  def test_truncated_violations_message
+    payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
+    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..160-1]
+    output = Librato::Services::Output.new(payload)
+
+    assert_equal(true, output.truncated_violations_message.length <= 140)
+    assert_equal(true, output.truncated_violations_message.end_with?('...'))
+  end
+
 end # class

--- a/test/output_test.rb
+++ b/test/output_test.rb
@@ -284,7 +284,7 @@ EOF
     assert_match("Alert Some_alert_name", output.generate_html)
   end
 
-  def test_sms_message
+  def test_violations_message
     payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
     output = Librato::Services::Output.new(payload)
 
@@ -306,21 +306,19 @@ EOF
     assert_equal(false, output.valid_sms?)
   end
 
-  def test_violations_message
+  def test_sms_message
+    payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
+    output = Librato::Services::Output.new(payload)
+
+    assert_equal(true, output.sms_message.length <= 140)
+  end
+
+  def test_truncated_sms_message
     payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
     payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..160-1]
     output = Librato::Services::Output.new(payload)
 
-    assert_equal(true, output.violations_message.length >= 140)
+    assert_equal(140, output.sms_message.length)
+    assert_equal(true, output.sms_message.end_with?('...'))
   end
-
-  def test_truncated_violations_message
-    payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
-    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..160-1]
-    output = Librato::Services::Output.new(payload)
-
-    assert_equal(true, output.truncated_violations_message.length <= 140)
-    assert_equal(true, output.truncated_violations_message.end_with?('...'))
-  end
-
 end # class

--- a/test/output_test.rb
+++ b/test/output_test.rb
@@ -284,4 +284,11 @@ EOF
     assert_match("Alert Some_alert_name", output.generate_html)
   end
 
+  def test_sms_message
+    payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
+    output = Librato::Services::Output.new(payload)
+
+    assert_match('metric `metric.name` from `foo.bar`', output.sms_message)
+  end
+
 end # class

--- a/test/output_test.rb
+++ b/test/output_test.rb
@@ -300,7 +300,7 @@ EOF
 
   def test_invalid_sms
     payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
-    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..160-1]
+    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..159]
     output = Librato::Services::Output.new(payload)
 
     assert_equal(false, output.valid_sms?)
@@ -315,7 +315,7 @@ EOF
 
   def test_truncated_sms_message
     payload = Librato::Services::Helpers::AlertHelpers.sample_new_alert_payload
-    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..160-1]
+    payload['violations']['foo.bar'][0]['metric'] = SecureRandom.urlsafe_base64(160)[0..159]
     output = Librato::Services::Output.new(payload)
 
     assert_equal(140, output.sms_message.length)

--- a/test/sns_test.rb
+++ b/test/sns_test.rb
@@ -65,8 +65,11 @@ class SNSTest < Librato::Services::TestCase
 
     expect(aws_stub).to receive(:publish).with(
       {
-        :topic_arn=>"arn:aws:sns:us-east-1:123456789012:test_topic-123",
-        :message=>"{\"alert\":\"some_alert\"}"
+        :topic_arn=>'arn:aws:sns:us-east-1:123456789012:test_topic-123',
+        :message=> {
+          :default => { :alert => 'some_alert' }.to_json,
+        }.to_json,
+        :message_structure => 'json'
       }
     )
 
@@ -146,6 +149,14 @@ class SNSTest < Librato::Services::TestCase
         triggered_by_user_test: true
       }))
     svc.receive_alert
+  end
+
+  def test_json_message_generator
+    payload = new_alert_payload.dup
+    svc = service(:alert, default_setting, payload)
+    hsh = JSON.parse(svc.json_message_generator_for({foo:'bar'}))
+
+    assert_equal(["default", "sms"], hsh.keys)
   end
 
   def assert_raise_with_message(klass, msg)

--- a/test/sns_test.rb
+++ b/test/sns_test.rb
@@ -65,8 +65,8 @@ class SNSTest < Librato::Services::TestCase
 
     expect(aws_stub).to receive(:publish).with(
       {
-        :topic_arn=>'arn:aws:sns:us-east-1:123456789012:test_topic-123',
-        :message=> {
+        :topic_arn => 'arn:aws:sns:us-east-1:123456789012:test_topic-123',
+        :message => {
           :default => { :alert => 'some_alert' }.to_json,
         }.to_json,
         :message_structure => 'json'
@@ -156,7 +156,7 @@ class SNSTest < Librato::Services::TestCase
     svc = service(:alert, default_setting, payload)
     hsh = JSON.parse(svc.json_message_generator_for({foo:'bar'}))
 
-    assert_equal(["default", "sms"], hsh.keys)
+    assert_equal(['default', 'sms'], hsh.keys)
   end
 
   def assert_raise_with_message(klass, msg)


### PR DESCRIPTION
Hotfix for SNS topics not delivering to SMS subscriptions. Result of SNS backend (silently?) failing when hitting SMS length limits from large JSON payloads. The following protocols are supported:

```json
{
  "default": "foobar", 
  "email": "foobar", 
  "sqs": "foobar", 
  "lambda": "foobar", 
  "http": "foobar", 
  "https": "foobar", 
  "sms": "foobar", 
  "APNS": "{\"aps\":{\"alert\": \"foobar\"} }", 
  "APNS_SANDBOX":"{\"aps\":{\"alert\":\"foobar\"}}", 
  "APNS_VOIP":"{\"aps\":{\"alert\":\"foobar\"}}", 
  "APNS_VOIP_SANDBOX": "{\"aps\":{\"alert\": \"foobar\"} }", 
  "MACOS":"{\"aps\":{\"alert\":\"foobar\"}}", 
  "MACOS_SANDBOX": "{\"aps\":{\"alert\": \"foobar\"} }", 
  "GCM": "{ \"data\": { \"message\": \"foobar\" } }", 
  "ADM": "{ \"data\": { \"message\": \"foobar\" } }", 
  "BAIDU": "{\"title\":\"foobar\",\"description\":\"foobar\"}", 
  "MPNS" : "<?xml version=\"1.0\" encoding=\"utf-8\"?><wp:Notification xmlns:wp=\"WPNotification\"><wp:Tile><wp:Count>ENTER COUNT</wp:Count><wp:Title>foobar</wp:Title></wp:Tile></wp:Notification>", 
  "WNS" : "<badge version\"1\" value\"23\"/>"
}
```

[`:message_structure`](http://docs.aws.amazon.com/sdkforruby/api/Aws/SNS/Topic.html#publish-instance_method) allows sending a different message for each protocol. We're only setting a specific message for SMS, then defaulting to the previous payload for the remaining protocols. Would've been nice to use [`#html`](https://github.com/librato/librato-services/blob/hotfix/sns-sms/lib/librato-services/output.rb#L34-L36) for `"email"`, but SNS unfortunately only renders `plain/text`.

![screenshot](http://i.imgur.com/0QIN3Qn.png)

@miketang415 