### PR TITLE
Hotfix/alert-clear

### DIFF
--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -145,10 +145,12 @@ module Librato
       end
 
       def sms_message
-        if valid_sms?
-          violations_message
-        else
-          violations_message.truncate(140)
+        unless @clear
+          if valid_sms?
+            violations_message
+          else
+            violations_message.truncate(140)
+          end
         end
       end
 

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -78,7 +78,12 @@ class Service::SNS < Service
       :default => msg.to_json
     }
 
-    if payload[:alert][:version] == 2
+    if payload[:clear]
+      trigger_time_utc = DateTime.strptime(payload[:trigger_time].to_s, "%s").strftime("%a, %b %e %Y at %H:%M:%S UTC")
+      cleared_message = "Alert '#{payload[:alert][:name]}' has cleared at #{trigger_time_utc}"
+      json[:default] = cleared_message
+      json[:sms] = cleared_message
+    elsif payload[:alert][:version] == 2
       json[:sms] = Librato::Services::Output.new(payload).sms_message
     end
 

--- a/test/sns_test.rb
+++ b/test/sns_test.rb
@@ -159,6 +159,14 @@ class SNSTest < Librato::Services::TestCase
     assert_equal(['default', 'sms'], hsh.keys)
   end
 
+  def test_json_message_generator_with_clear
+    payload = new_alert_payload.dup
+    svc = service(:alert, default_setting, payload.merge({clear:'auto'}))
+    hsh = JSON.parse(svc.json_message_generator_for({foo:'bar'}))
+
+    assert_match("Alert 'Some alert name' has cleared at", hsh['sms'])
+  end
+
   def assert_raise_with_message(klass, msg)
     begin
       yield


### PR DESCRIPTION
Hotfix for SNS alert clearing. `"violations"` and `"conditions"` are nil on alert clear. Do not attempt to build sms message when that occurs, send `"Alert has cleared"` message instead.

@akahn 