### PR TITLE
Better alert violation times for windowed alerts

### DIFF
--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -107,7 +107,8 @@ module Librato
         else
           metric = "`#{measurement[:metric]}`"
         end
-        "metric #{metric} was #{format_violation_type(condition, measurement)} recorded at #{format_time(measurement[:recorded_at])}"
+        violation_time = measurement[:end] || measurement[:recorded_at]
+        "metric #{metric} was #{format_violation_type(condition, measurement)} recorded at #{format_time(violation_time)}"
       end
 
       def format_violation_type(condition, measurement)

--- a/test/output_test.rb
+++ b/test/output_test.rb
@@ -215,7 +215,7 @@ EOF
         violations: {
             "foo.bar" => [{
                               metric: "metric.name", value: 100, recorded_at: 1389391083,
-                              condition_violated: 1, count: 10, begin: 12321123, end: 12321183
+                              condition_violated: 1, count: 10, begin: 1389390903, end: 1389390993
                           }]
         }
     }
@@ -226,7 +226,7 @@ EOF
 Link: https://metrics.librato.com/alerts/123
 
 Source `foo.bar`:
-* metric `metric.name` was above threshold 10 over 60 seconds with value 100 recorded at Fri, Jan 10 2014 at 21:58:03 UTC
+* metric `metric.name` was above threshold 10 over 90 seconds with value 100 recorded at Fri, Jan 10 2014 at 21:56:33 UTC
 EOF
     assert_equal(expected, output.markdown)
   end


### PR DESCRIPTION
Violation end times are rendered using the violation's `end` property if it exists (windowed alert). If it doesn't it falls back to the violation's `recorded_at` time.