### PR TITLE
Bugfix/victor ops alert

### DIFF
--- a/services/victorops.rb
+++ b/services/victorops.rb
@@ -25,16 +25,12 @@ class Service::VictorOps < Service
       body.delete :api_key
 
       # Keys that will soon be in the payload
-      body[:entity_id] = payload[:incident_key] || payload['alert']['id']
+      body[:entity_id] = payload['alert']['name'] || payload['alert']['id'] || payload[:incident_key]
       if payload[:clear]
         body[:clear] = payload[:clear]
         body[:message_type] = "RECOVERY"
       else
         body[:message_type] = "CRITICAL"
-      end
-      
-      if payload['alert']['name']
-        body['state_message'] = payload['alert']['name']
       end
 
       # Fire

--- a/services/victorops.rb
+++ b/services/victorops.rb
@@ -32,6 +32,10 @@ class Service::VictorOps < Service
       else
         body[:message_type] = "CRITICAL"
       end
+      
+      if payload['alert']['name']
+        body['state_message'] = payload['alert']['name']
+      end
 
       # Fire
       uri = uri_for_key(settings[:api_key])


### PR DESCRIPTION
This fixes an issue where the entity_id in the VictorOps payload was using their random UUID they generate. We now use the alert name first, followed by the alert ID and then, if all else fails, the alert UUID.