### PR TITLE
AWS Lambda notification service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'flowdock', '~> 0.3'
 gem 'customerio', '~> 0.5'
 
 # service :aws-sns
-gem 'aws-sdk-core', '~> 2.0.18'
+gem 'aws-sdk-core', '~> 2.6.35'
 
 # markdown generation
 gem 'redcarpet', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,10 @@ GEM
       tzinfo (~> 0.3.37)
     addressable (2.3.6)
     atomic (1.1.14)
-    aws-sdk-core (2.0.18)
-      builder (~> 3.0)
+    aws-sdk-core (2.6.35)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-      multi_json (~> 1.0)
-      multi_xml (~> 0.5)
+    aws-sigv4 (1.0.0)
     builder (3.2.2)
     customerio (0.5.0)
       httparty (>= 0.5, < 1.0)
@@ -54,8 +53,7 @@ GEM
       nokogiri (>= 1.5.10)
       rake
       rdoc
-    jmespath (1.0.2)
-      multi_json (~> 1.0)
+    jmespath (1.3.1)
     json (1.8.1)
     jwt (1.0.0)
     mail (2.5.4)
@@ -128,7 +126,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 3.2)
-  aws-sdk-core (~> 2.0.18)
+  aws-sdk-core (~> 2.6.35)
   customerio (~> 0.5)
   faraday (~> 0.8)
   flowdock (~> 0.3)
@@ -145,4 +143,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.10.5
+   1.12.5

--- a/services/lambda.rb
+++ b/services/lambda.rb
@@ -1,0 +1,109 @@
+# encoding: utf-8
+
+require 'aws-sdk-core'
+
+class Service::Lambda < Service
+
+  def receive_validate(errors = {})
+    success = true
+    [:function_arn].each do |k|
+      value = settings[k]
+      if value.to_s.empty?
+        errors[k] = 'Is required'
+        success = false
+      end
+    end
+
+    return false unless success
+
+    unless settings[:function_arn] =~ /\Aarn:aws:lambda:[^:]+:[0-9]+:function:[a-zA-Z0-9\-_\.:]+\Z/
+      errors[:function_arn] =
+        'Should have format "arn:aws:lambda:<region>:<account>:function:<function_name>" with'\
+        'only alphanumeric characters, hyphens and underscores in function name.'
+       success = false
+    end
+
+    success
+  end
+
+  def receive_alert_clear
+    receive_notification('alert_clear')
+  end
+
+  def receive_alert
+    receive_notification('alert_trigger')
+  end
+
+  def receive_snapshot
+    receive_notification('snapshot')
+  end
+
+  private
+
+  def receive_notification(type)
+    raise_config_error unless receive_validate({})
+
+    msg = build_payload(type, payload)
+    publish_message(msg)
+  end
+
+  private
+
+  def build_payload(event_type, payload)
+    p = {'event_type' => event_type}
+
+    if payload['alert']
+      p['alert'] = payload['alert']
+
+      if payload['alert']['version'] == 2
+        p['trigger_time'] = payload['trigger_time']
+        p['conditions'] = payload['conditions']
+        p['violations'] = payload['violations']
+
+        if payload['triggered_by_user_test']
+          p['triggered_by_user_test'] = payload['triggered_by_user_test']
+        end
+
+        if payload['incident_key']
+          p['incident_key'] = payload['incident_key']
+        end
+      end
+    end
+
+    if payload['snapshot']
+      p['snapshot'] = payload['snapshot']
+    end
+
+    p
+  end
+
+  def publish_message(msg)
+    resp = lambda.invoke({function_name: function_arn, invocation_type: 'Event', log_type: 'None', payload: msg.to_json})
+    if resp.status_code / 100 != 2
+      raise_error "Failed to invoke #{function_arn}: #{resp.status_code}/#{resp.function_error}"
+    end
+  rescue Aws::Lambda::Errors::ResourceNotFoundException
+    raise_config_error "Lambda function does not exist: #{function_arn}"
+  rescue Aws::Lambda::Errors::AccessDeniedException
+    raise_config_error 'Authorization failed - ensure that Librato is allowed to invoke the lambda function'
+  rescue Aws::Lambda::Errors::ServiceError => e
+    raise_error e.message
+  end
+
+  def region
+    @region ||=
+      function_arn =~ /arn:aws:lambda:([^:]+):/ ? $1 : raise_config_error('Invalid function ARN (could not find region)')
+  end
+
+  def function_arn
+    @function_arn ||= settings[:function_arn]
+  end
+
+  def lambda
+    @lambda ||=
+      Aws::Lambda::Client.new(
+        credentials: Aws::Credentials.new(ENV['LAMBDA_INVOCATION_ACCESS_ID'], ENV['LAMBDA_INVOCATION_ACCESS_KEY']),
+        region: region)
+  end
+
+end

--- a/services/lambda.rb
+++ b/services/lambda.rb
@@ -1,5 +1,98 @@
 # encoding: utf-8
 
+#
+# AWS Lambda Librato service
+# --------------------------
+#
+# Deliver Librato alert triggers/clears and snapshots to an AWS Lambda
+# function.
+#
+# Configuration
+# =============
+#
+#   function_arn: (required) ARN of function name
+#        Example: arn:aws:lambda:us-west-2:1234567890:function:my-simple-func
+#
+# The function must be given `lambda:InvokeFunction` permission from the
+# Librato AWS Account ID. For example, to add permission to a function
+# name of "my-simple-func" in the "us-west-2" region using the AWS
+# CLI:
+#
+#  $ aws lambda add-permission --function-name my-simple-func \
+#                         --region us-west-2 \
+#                         --action "lambda:InvokeFunction" \
+#                         --principal <Librato AWS Account ID> \
+#                         --statement-id Id-123
+#
+# The following environment variables must be set to the callee
+# account's AWS credentials:
+#
+#  LAMBDA_INVOCATION_ACCESS_ID
+#  LAMBDA_INVOCATION_ACCESS_KEY
+#
+# Description
+# ===========
+#
+# This service will invoke the function asynchronously (invocation
+# type: 'Event) and pass the alert or snapshot JSON payload.
+#
+# The payload will contain the key 'event_type' set to the value of
+# either: 'alert_trigger', 'alert_clear', or 'snapshot' and can be
+# used to identify the type of event.
+#
+# A triggered alert payload looks like (only v2 alerts are supported):
+#
+#  {
+#    "event_type":"alert_trigger",
+#    "trigger_time":12321123,
+#    "alert":{
+#       "runbook_url":"http://runbooks.com/howtodoit",
+#       "description":"Verbose alert explanation",
+#       "version":2,
+#       "id":123,
+#       "name":"Some alert name"
+#    },
+#    "incident_key":"foo",
+#    "violations":{
+#       "foo.bar":[
+#          {
+#             "metric":"metric.name",
+#             "condition_violated":1,
+#             "value":100,
+#             "recorded_at":1389391083
+#          }
+#       ]
+#    },
+#    "conditions":[
+#       {
+#          "threshold":10,
+#          "type":"above",
+#          "id":1
+#       }
+#    ]
+# }
+#
+# A snapshot payload looks like:
+#
+# {
+#    "event_type":"snapshot",
+#    "snapshot":{
+#       "entity_name":"App API Requests",
+#       "entity_url":"https://metrics.librato.com/instruments/1234?duration=3600",
+#       "image_url":"http://snapshots.librato.com/instruments/12345abcd.png",
+#       "user":{
+#          "email":"mike@librato.com",
+#          "full_name":"Librato User"
+#       },
+#       "message":"Explanation of this snapshot",
+#       "subject":"Subject of API Requests"
+#    }
+# }
+
+#
+######
+
+
 require 'aws-sdk-core'
 
 class Service::Lambda < Service

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -71,7 +71,7 @@ class Service::SNS < Service
     sns.publish(topic_arn: topic_arn, message: json_message_generator_for(msg), message_structure: 'json')
   rescue Aws::SNS::Errors::SignatureDoesNotMatch
     raise_config_error 'Authentication failed - incorrect access key id or access key secret'
-  rescue Aws::SNS::Errors::AuthorizationError
+  rescue Aws::SNS::Errors::AuthorizationErrorException
     raise_config_error 'Authorization failed - ensure that the user is allowed to perform SNS:Publish action '\
                        'on the topic and that the topic arn is correct'
   rescue Aws::SNS::Errors::ServiceError => e

--- a/test/lambda_test.rb
+++ b/test/lambda_test.rb
@@ -1,0 +1,105 @@
+require File.expand_path('../helper', __FILE__)
+require 'rspec/mocks/standalone'
+
+class LambdaTest < Librato::Services::TestCase
+  include ::RSpec::Mocks::ExampleMethods
+
+  def before_setup
+    ::RSpec::Mocks.setup
+    super
+  end
+
+  def test_validations
+    svc = service(:alert, default_setting, new_alert_payload)
+    errors = {}
+    assert(svc.receive_validate(errors))
+    assert(errors.empty?)
+
+    # Missing
+    svc = service(:alert, {}, new_alert_payload)
+    errors = {}
+    assert(!svc.receive_validate(errors))
+    assert_equal(1, errors.length)
+    errors.each_value { |err| assert(err.include?("Is required")) }
+
+    # Invalid function ARNs
+    [
+     "arn:aws:sns:us-west-2:1234567890:function:my-simple-function",
+     "arn:aws:lambda:us-west-2:1234567890:my-simple-function",
+     "arn:aws:lambda:us-west-2:1234567890:function:",
+     "arn:aws:lambda:1234567890:function:my-simple-function",
+     "my-simple-function"
+    ].each do |arn|
+      svc = service(:alert, default_setting(function_arn: arn), new_alert_payload)
+      errors = {}
+
+      assert(!svc.receive_validate(errors))
+      assert_equal(1, errors.length)
+      assert(errors[:function_arn].include?('Should have format "arn:aws:lambda'))
+    end
+
+    # Valid function ARNs
+    [
+     "arn:aws:lambda:us-west-2:1234567890:function:my-simple-func",
+     "arn:aws:lambda:us-west-2:1234567890:function:my-simple-func:some-alias",
+     "arn:aws:lambda:us-west-2:1234567890:function:my-simple-func:1.0",
+    ].each do |arn|
+      svc = service(:alert, default_setting(function_arn: arn), new_alert_payload)
+      errors = {}
+
+      assert(svc.receive_validate(errors))
+      assert(errors.empty?)
+    end
+  end
+
+  def test_deliver_msg
+    aws_stub = Aws::Lambda::Client.new(stub_responses: true, credentials: Aws::Credentials.new("key","secret"))
+    expect(Aws::Lambda::Client).to receive(:new).and_return aws_stub
+    aws_stub.stub_responses(:invoke,
+                            Aws::Lambda::Errors::ResourceNotFoundException.new(nil, ''),
+                            Aws::Lambda::Errors::AccessDeniedException.new(nil, ''),
+                            Aws::Lambda::Errors::ServiceError.new(nil, 'Some horrible AWS Error'))
+
+    svc = service(:alert, default_setting, new_alert_payload)
+
+    assert_raise_with_message(Librato::Services::Service::ConfigurationError,
+                              'Lambda function does not exist') do
+      svc.receive_alert()
+    end
+
+    assert_raise_with_message(Librato::Services::Service::ConfigurationError,
+                              'Authorization failed') do
+      svc.receive_alert()
+    end
+
+    assert_raise_with_message(Librato::Services::Service::ServiceError, 'Some horrible AWS Error') do
+      svc.receive_alert()
+    end
+  end
+
+  def assert_raise_with_message(klass, msg)
+    begin
+      yield
+      assert(false, "Expected exception #{klass} was not raised")
+    rescue klass => e
+      assert(e.message.include?(msg), "Exception message \"#{e.message}\" did not include expected message \"#{msg}\"")
+    end
+  end
+
+  def service(*args)
+    super Service::Lambda, *args
+  end
+
+  def default_setting(overrides = {})
+    {
+      function_arn: "arn:aws:lambda:us-west-2:1234567890:function:my-simple-func"
+    }.merge(overrides)
+  end
+
+  def after_teardown
+    super
+    ::RSpec::Mocks.verify
+  ensure
+    ::RSpec::Mocks.teardown
+  end
+end

--- a/test/sns_test.rb
+++ b/test/sns_test.rb
@@ -43,8 +43,8 @@ class SNSTest < Librato::Services::TestCase
     aws_stub = Aws::SNS::Client.new(stub_responses: true, credentials: Aws::Credentials.new("key","secret"))
     expect(Aws::SNS::Client).to receive(:new).and_return aws_stub
     aws_stub.stub_responses(:publish,
-                            Aws::SNS::Errors::SignatureDoesNotMatch,
-                            Aws::SNS::Errors::AuthorizationError,
+                            Aws::SNS::Errors::SignatureDoesNotMatch.new(nil, ''),
+                            Aws::SNS::Errors::AuthorizationErrorException.new(nil, ''),
                             Aws::SNS::Errors::ServiceError.new(nil, 'Some horrible AWS Error'))
 
     svc = service(:alert, default_setting, alert_payload)


### PR DESCRIPTION
Invokes an async, cross-account, AWS Lambda function on alert trigger/clear or snapshot event. Just register an AWS Lambda function ARN and give it InvokeFunction permissions from the callee account.

Removes the need to setup either an SNS or API Gateway (webhook) resource to invoke a Lambda function on Librato notification.

See additional documentation at the top of lambda service file.