### PR TITLE
Don't fail if one email is invalid

### DIFF
--- a/services/mail.rb
+++ b/services/mail.rb
@@ -3,6 +3,8 @@ require 'erb'
 require 'mail'
 
 class Service::Mail < Service
+  EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+/
+
   def receive_validate(errors)
     addresses = settings[:addresses]
     if addresses.to_s.empty?
@@ -85,6 +87,7 @@ class Service::Mail < Service
 
   def filter_addresses(addresses)
     addresses.reject {|a| email_blacklist.include?(a.downcase) }
+             .reject {|a| !EMAIL_REGEX.match(a) }
   end
 
   #TODO change when no longer "new"

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -63,11 +63,29 @@ class MailTest < Librato::Services::TestCase
     svc.mail_message.perform_deliveries = false
     svc.receive_alert
   end
-
+  
   def test_mail_message_alert
     svc = service(:alert, { :addresses => 'fred@barn.com' }, alert_payload)
     message = svc.mail_message
     assert_equal "[Librato] Alert  has triggered!", message.subject
+    assert_not_nil message
+    assert(!message.to.empty?)
+  end
+
+  def test_mail_message_alert_multiple_emails
+    svc = service(:alert, { :addresses => 'fred@barn.com,test@librato.local' }, alert_payload)
+    message = svc.mail_message
+    assert_equal "[Librato] Alert  has triggered!", message.subject
+    assert_equal ['fred@barn.com', 'test@librato.local'], message.to
+    assert_not_nil message
+    assert(!message.to.empty?)
+  end
+
+  def test_mail_message_alert_multiple_emails_one_invalid
+    svc = service(:alert, { :addresses => 'fred@barn.com,test@@librato.local' }, alert_payload)
+    message = svc.mail_message
+    assert_equal "[Librato] Alert  has triggered!", message.subject
+    assert_equal ['fred@barn.com'], message.to
     assert_not_nil message
     assert(!message.to.empty?)
   end


### PR DESCRIPTION
If you have an invalid email, say one with two `@` in the address, in the list of addresses, we don't send any alerts.

We are still discussing if we want to fail the whole message or, using the change below, reject the invalid email that snuck through validation.