### PR TITLE
Add incident_key to webhook payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A sample payload is available at
     "name" : "Alert name or nil",
     "id" : 12345,
   },
+  "incident_key": "<key that uniquely identifies this alert incident>",
   "metric" : {
      "name" : "Name of the metric that tripped alert",
      "type" : "gauge" or "counter",
@@ -74,6 +75,7 @@ Payload for a Cleared Alert
       "runbook_url":"",
       "version":2
    },
+   "incident_key": "<key that uniquely identifies this alert incident>",
    "account":"youremail@yourdomain.com",
    "trigger_time":1457040045,
    "clear":"normal"

--- a/services/webhook.rb
+++ b/services/webhook.rb
@@ -41,7 +41,8 @@ module Librato::Services
         :alert => payload['alert'],
         :account => account_email,
         :trigger_time => payload['trigger_time'],
-        :clear => "normal"
+        :clear => "normal",
+        :incident_key => payload['incident_key']
       }
       post_it(uri, result)
     end
@@ -55,6 +56,7 @@ module Librato::Services
           :alert => payload['alert'],
           :account => account_email,
           :trigger_time => payload['trigger_time'],
+          :incident_key => payload['incident_key'],
           :conditions => payload['conditions'],
           :violations => payload['violations'],
           :triggered_by_user_test => payload['triggered_by_user_test']

--- a/test/webhook_test.rb
+++ b/test/webhook_test.rb
@@ -62,12 +62,13 @@ module Librato::Services
 
       @stubs.post "#{path}" do |env|
         payload = JSON.parse(env[:body][:payload])
-        assert_equal ["account", "alert", "conditions", "trigger_time", "triggered_by_user_test", "violations"], payload.keys.sort
+        assert_equal ["account", "alert", "conditions", "incident_key", "trigger_time", "triggered_by_user_test", "violations"], payload.keys.sort
         assert_equal 123, payload['alert']['id']
         assert_equal 'Some alert name', payload['alert']['name']
         assert_equal 1, payload['conditions'].length
         assert_equal "foo@example.com", payload['account']
         assert_equal false, payload['triggered_by_user_test']
+        assert_equal 'foo', payload['incident_key']
         violations = payload['violations']
         foo_bar_violations = violations['foo.bar']
         assert_equal 1, foo_bar_violations.length


### PR DESCRIPTION
This will allow users (Heroku requested this) to uniquely identify alert
incidences.

According to my reading of librato/alerts, incident key is always
included in payloads.