### PR TITLE
Enable v3 url structure for alert links [AO-12992]

### DIFF
--- a/lib/librato-services/helpers/alert_helpers.rb
+++ b/lib/librato-services/helpers/alert_helpers.rb
@@ -93,8 +93,14 @@ module Librato
           "https://#{ENV['METRICS_APP_URL']}/metrics/#{name}"
         end
 
-        def alert_link(id)
-          "https://#{ENV['METRICS_APP_URL']}/alerts/#{id}"
+        def alert_link(payload)
+          alert_id = payload['alert']['id']
+          if ENV['ALERTS_V3_LINK'] && payload['user_id']
+            path = "#{payload['user_id']}/details/#{alert_id}"
+          else
+            path = alert_id
+          end
+          "https://#{ENV['METRICS_APP_URL']}/alerts/#{path}"
         end
 
         # TODO: fix for specific alert id?

--- a/lib/librato-services/output.rb
+++ b/lib/librato-services/output.rb
@@ -12,7 +12,7 @@ module Librato
     class Output
       include Helpers::AlertHelpers
 
-      attr_reader :violations, :conditions, :alert, :clear, :trigger_time
+      attr_reader :violations, :conditions, :alert, :clear, :trigger_time, :alert_url
       def initialize(payload, add_test_notice=true)
         if !payload[:clear]
           # conditions and violations are required for faults
@@ -31,6 +31,7 @@ module Librato
         @trigger_time = payload[:trigger_time]
         @auth = payload[:auth] || {}
         @show_test_notice = (add_test_notice and payload[:triggered_by_user_test])
+        @alert_url = alert_link(payload.with_indifferent_access)
       end
 
       def html
@@ -65,7 +66,7 @@ module Librato
         if @auth[:email]
           result_array << "Account: #{@auth[:email]}\n"
         end
-        result_array << "Link: #{alert_link(@alert[:id])}\n"
+        result_array << "Link: #{@alert_url}\n"
         @violations.each do |source, measurements|
           result_array << "Source `#{source}`:"
           measurements.each do |measurement|
@@ -97,7 +98,7 @@ module Librato
         if @auth[:email]
           lines << "Account: #{@auth[:email]}\n"
         end
-        lines << "Link: #{alert_link(@alert[:id])}\n"
+        lines << "Link: #{@alert_url}\n"
         lines.join("\n")
       end
 

--- a/services/big_panda.rb
+++ b/services/big_panda.rb
@@ -45,7 +45,7 @@ module Librato::Services
 
       body['description'] = payload['alert']['description'] if payload['alert']['description']
       body['runbook_url'] = payload['alert']['runbook_url'] if present?(payload['alert']['runbook_url'])
-      body['link'] = alert_link(payload['alert']['id'])
+      body['link'] = alert_link(payload)
 
       if payload[:triggered_by_user_test]
         body['note'] = test_alert_message()

--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -55,7 +55,7 @@ module Librato::Services
       if payload[:alert][:version] == 1
         body[:details][:metric_url] = payload_link(payload)
       end
-      body[:details][:alert_url] = alert_link(payload['alert']['id'])
+      body[:details][:alert_url] = alert_link(payload)
       unless payload['alert']['runbook_url'].blank?
         body[:details][:runbook_url] = payload['alert']['runbook_url']
       end

--- a/services/slack.rb
+++ b/services/slack.rb
@@ -29,11 +29,11 @@ module Librato::Services
       if data.clear
         text = case data.clear
                when "manual"
-                 "Alert <#{alert_link(data.alert[:id])}|#{data.alert[:name]}> was manually cleared at #{trigger_time_utc}"
+                 "Alert <#{data.alert_url}|#{data.alert[:name]}> was manually cleared at #{trigger_time_utc}"
                when "auto"
-                 "Alert <#{alert_link(data.alert[:id])}|#{data.alert[:name]}> was automatically cleared at #{trigger_time_utc}"
+                 "Alert <#{data.alert_url}|#{data.alert[:name]}> was automatically cleared at #{trigger_time_utc}"
                else
-                 "Alert <#{alert_link(data.alert[:id])}|#{data.alert[:name]}> has cleared at #{trigger_time_utc}"
+                 "Alert <#{data.alert_url}|#{data.alert[:name]}> has cleared at #{trigger_time_utc}"
                end
         fallback = case data.clear
                    when "manual"
@@ -57,7 +57,7 @@ module Librato::Services
         if payload[:triggered_by_user_test]
           pretext << "#{test_alert_message()}\n\n"
         end
-        pretext << "Alert <#{alert_link(data.alert[:id])}|#{data.alert[:name]}> has triggered!"
+        pretext << "Alert <#{data.alert_url}|#{data.alert[:name]}> has triggered!"
         unless runbook_url.blank?
           pretext << " <#{runbook_url}|Runbook>"
         end
@@ -91,7 +91,7 @@ module Librato::Services
     def format_fallback(data)
       data.markdown.sub(/^#\s+/, '').                 # no leading #
         gsub('`', '\'').                              # no backticks
-        chomp + " • #{alert_link(data.alert[:id])}\n" # add the alert link
+        chomp + " • #{data.alert_url}\n"            # add the alert link
     end
 
     def raise_url_error


### PR DESCRIPTION
:ticket: https://swicloud.atlassian.net/browse/AO-12992

Now that we're transitioning to the v3 alerts interface in AO, we want to update notification links to use the new URL structure, including org ID. I _think_ `payload['user_id']` always exists now (despite it only being present in the `sample_new_alert_payload`) and actually matches the org ID (thanks to org ghost owner magic). We don't want to mess with Librato alerts, so I put the change behind an `ALERTS_V3_LINK` env var (though I have no idea where in `app-environs` that actually needs to be set…).

This is a pretty naive first pass. I would greatly appreciate feedback and advice on next steps / how to actually get this out there, since I'm not at all familiar with how/where this code actually gets run.

TODO: add some tests once I know I'm on the right track